### PR TITLE
Refactor bin

### DIFF
--- a/bin/underreact.js
+++ b/bin/underreact.js
@@ -149,20 +149,24 @@ function getConfig(command, argv) {
       } else if (argv.env === 'prod') {
         production = true;
       }
+
       // This object is passed as the argument to the config module, if it's a
       // function.
       const configModuleContext = {
         webpack,
         command,
-        production,
-        argv,
-        configDir: path.dirname(configPath),
-        stats: argv.stats,
-        port: argv.port
+        production
       };
-      const defaultConfig = getDefaultConfig(configModuleContext);
-      const userConfig = getUserConfig(configModuleContext);
 
+      const userConfig = getUserConfig(configModuleContext);
+      const defaultConfig = getDefaultConfig(
+        Object.assign({}, configModuleContext, {
+          argv,
+          configDir: path.dirname(configPath),
+          stats: argv.stats,
+          port: argv.port
+        })
+      );
       return normalizeConfig(userConfig, defaultConfig);
     });
 }

--- a/bin/underreact.js
+++ b/bin/underreact.js
@@ -5,11 +5,12 @@ const yargs = require('yargs');
 const path = require('path');
 const chalk = require('chalk');
 const webpack = require('webpack');
+
 const start = require('../commands/start');
 const build = require('../commands/build');
 const serveStatic = require('../commands/serve-static');
-const writeBabelrc = require('../commands/write-babelrc');
 const logger = require('../lib/logger');
+const { DEFAULT_CONFIG_NAME } = require('../lib/constants');
 const normalizeConfig = require('../lib/normalize-config');
 const getDefaultConfig = require('../lib/default-underreact.config');
 
@@ -59,12 +60,6 @@ yargs
     defineServeStatic,
     runServeStatic
   )
-  .command(
-    'write-babelrc [options]',
-    'Write a .babelrc file.',
-    defineWriteBabelrc,
-    runWriteBabelrc
-  )
   .demand(1, 'You must specify a command')
   .example('underreact start')
   .example('underreact build -c conf/clf.js')
@@ -85,11 +80,9 @@ function defineStart(y) {
 }
 
 function runStart(argv) {
-  try {
-    start(getConfig('start', argv));
-  } catch (error) {
-    errorOut(error);
-  }
+  getConfig('start', argv)
+    .then(urc => start(urc))
+    .catch(errorOut);
 }
 
 function defineBuild(y) {
@@ -105,11 +98,9 @@ function defineBuild(y) {
 }
 
 function runBuild(argv) {
-  try {
-    build(getConfig('build', argv));
-  } catch (error) {
-    errorOut(error);
-  }
+  getConfig('build', argv)
+    .then(urc => build(urc))
+    .catch(errorOut);
 }
 
 function defineServeStatic(y) {
@@ -120,87 +111,69 @@ function defineServeStatic(y) {
 }
 
 function runServeStatic(argv) {
-  try {
-    serveStatic(getConfig('serve-static', argv));
-  } catch (error) {
-    errorOut(error);
-  }
-}
-
-function defineWriteBabelrc(y) {
-  y.version(false)
-    .option(...configOption)
-    .option('output', {
-      description: 'Directory where .babelrc should be written',
-      alias: 'o',
-      type: 'string',
-      normalize: true,
-      default: '.'
-    })
-    .help();
-}
-
-function runWriteBabelrc(argv) {
-  try {
-    writeBabelrc(getConfig('write-babelrc', argv), argv.output, argv.env);
-  } catch (error) {
-    errorOut(error);
-  }
+  getConfig('serve-static', argv)
+    .then(urc => serveStatic(urc))
+    .catch(errorOut);
 }
 
 function getConfig(command, argv) {
   const configIsNotSpecified = argv.config === undefined;
   let configPath;
+
   if (configIsNotSpecified) {
-    configPath = path.join(process.cwd(), 'underreact.config.js');
+    configPath = path.join(process.cwd(), DEFAULT_CONFIG_NAME);
   } else {
-    configPath = path.isAbsolute(argv.config)
-      ? argv.config
-      : path.join(process.cwd(), argv.config);
-  }
-  let production = true;
-  if (command === 'build') {
-    production = !argv.debug;
-  } else if (command === 'start') {
-    production = argv.production;
-  } else if (command === 'write-babelrc' && argv.env === 'prod') {
-    production = true;
+    configPath = path.resolve(argv.config);
   }
 
-  // This object is passed as the argument to the config module, if it's a
-  // function.
-  const configModuleContext = {
-    webpack,
-    command,
-    production,
-    argv,
-    configDir: path.dirname(configPath),
-    stats: argv.stats,
-    port: argv.port
-  };
-
-  const defaultConfig = getDefaultConfig(configModuleContext);
-
-  let userConfig = {};
-  // If the user didn't use --config, it's fine if the default does not exist.
-  // But if they did specify a path, tell them if it doesn't work.
-  try {
-    const configModule = require(configPath);
-    userConfig =
-      typeof configModule === 'function'
-        ? configModule(configModuleContext)
-        : configModule;
-  } catch (error) {
-    if (!configIsNotSpecified) {
-      logger.error(
-        `Failed to load configuration module from ${chalk.underline(
+  return userConfigReader(configPath)
+    .catch(() => {
+      // If the user didn't use --config, it's fine if the underreact.config.js
+      // does not exist at the default path.
+      if (configIsNotSpecified) {
+        return () => {};
+      }
+      // But if they did specify a path, tell them it didn't work.
+      throw new Error(
+        `Failed to load underreact configuration module from ${chalk.underline(
           configPath
         )}`
       );
-    }
-  }
+    })
+    .then(getUserConfig => {
+      let production = true;
+      if (command === 'build') {
+        production = !argv.debug;
+      } else if (command === 'start') {
+        production = argv.production;
+      } else if (argv.env === 'prod') {
+        production = true;
+      }
+      // This object is passed as the argument to the config module, if it's a
+      // function.
+      const configModuleContext = {
+        webpack,
+        command,
+        production,
+        argv,
+        configDir: path.dirname(configPath),
+        stats: argv.stats,
+        port: argv.port
+      };
+      const defaultConfig = getDefaultConfig(configModuleContext);
+      const userConfig = getUserConfig(configModuleContext);
 
-  return normalizeConfig(userConfig, defaultConfig);
+      return normalizeConfig(userConfig, defaultConfig);
+    });
+}
+
+function userConfigReader(configPath) {
+  return Promise.resolve().then(() => {
+    const configModule = require(configPath);
+    return typeof configModule === 'function'
+      ? configModule
+      : () => configModule;
+  });
 }
 
 function errorOut(error) {

--- a/commands/build.js
+++ b/commands/build.js
@@ -6,8 +6,8 @@ const chalk = require('chalk');
 const createWebpackConfig = require('../lib/create-webpack-config');
 const logger = require('../lib/logger');
 const publicFilesCopier = require('../lib/public-files-copier');
-const htmlCompiler = require('../lib/html-compiler');
-const cssCompiler = require('../lib/css-compiler');
+const { writeHtml } = require('../lib/html-compiler');
+const { writeCss } = require('../lib/css-compiler');
 const writeWebpackStats = require('../lib/write-webpack-stats');
 const webpackPromise = require('../lib/webpack-promise');
 
@@ -24,9 +24,9 @@ function build(urc) {
         writeWebpackStats(urc.stats, stats);
       }
     })
-    .then(() => cssCompiler.write(urc))
-    .then(cssFilename => htmlCompiler.write(urc, cssFilename))
-    .then(() => publicFilesCopier.copy(urc))
+    .then(() => writeCss(urc))
+    .then(cssFilename => writeHtml(urc, cssFilename))
+    .then(() => publicFilesCopier(urc))
     .then(() => {
       // Clean up files you won't need to deploy.
       del.sync(path.join(urc.outputDirectory, 'assets.json'));

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -40,10 +40,6 @@ module.exports = ({ webpack, production }) => {
     environmentVariables: [
       'ENV_VAR'
     ],
-    browserslist: [
-      "last 2 chrome version",
-      "ie 11"
-    ],
     webpackConfigTransform: config => {
       config.devtool = false;
       return config;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   CSS_BASENAME: 'underreact-styles.css',
+  DEFAULT_CONFIG_NAME: 'underreact.config.js',
   WEBPACK_ASSETS_BASENAME: 'assets.json'
 };

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -6,6 +6,10 @@ const autoprefixer = require('autoprefixer');
 const postcssConcatenator = require('./packageable/postcss-concatenator');
 const { CSS_BASENAME } = require('./constants');
 
+module.exports = {
+  writeCss
+};
+
 function writeCss(urc) {
   if (urc.stylesheets.length === 0) {
     return Promise.resolve();
@@ -21,7 +25,3 @@ function writeCss(urc) {
     hash: urc.production
   });
 }
-
-module.exports = {
-  writeCss
-};

--- a/lib/html-compiler.js
+++ b/lib/html-compiler.js
@@ -8,6 +8,8 @@ const pify = require('pify');
 
 const { CSS_BASENAME } = require('./constants');
 
+module.exports = { renderHtml, writeHtml };
+
 function renderHtml(urc, cssFilename) {
   const assets = urc.getAssets();
   // Inline the runtime JS because it's super small.
@@ -71,10 +73,7 @@ function uglifyRuntime(urc, assets) {
 }
 
 function writeHtml(urc, cssFilename) {
-  // TOFIX renderHtml takes cssFilename param?
   return renderHtml(urc, cssFilename).then(html =>
     pify(fs.writeFile)(path.join(urc.outputDirectory, 'index.html'), html)
   );
 }
-
-module.exports = { renderHtml, writeHtml };

--- a/lib/public-files-copier.js
+++ b/lib/public-files-copier.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const autoCopy = require('./packageable/auto-copy');
-const logger = require('./logger');
+
+module.exports = copyPublicFiles;
 
 function copyPublicFiles(urc) {
   return autoCopy.copy({
@@ -9,22 +10,3 @@ function copyPublicFiles(urc) {
     destDir: urc.outputDirectory
   });
 }
-
-function watchPublicFiles(urc) {
-  const copier = autoCopy.watch({
-    sourceDir: urc.publicDirectory,
-    destDir: urc.outputDirectory
-  });
-  copier.on('copy', filename => {
-    logger.log(`Copying ${filename}`);
-  });
-  copier.on('delete', filename => {
-    logger.log(`Deleting ${filename}`);
-  });
-  copier.on('error', logger.error);
-}
-
-module.exports = {
-  copy: copyPublicFiles,
-  watch: watchPublicFiles
-};


### PR DESCRIPTION
This depends on the review of #6 .

- This refactor `try-catch` to use Promises. Makes it easier to compose and trickle error up.
- Gets rid of `.babelrc` related functions as we are going to take a different approach than writing babelrc.
- Fixes the build and start files
- Moves `module.exports` to top so that one doesn't have to scroll down to find what is being exported. 