### PR TITLE
Fix config for post-css

### DIFF
--- a/examples/fancy/src/html.js
+++ b/examples/fancy/src/html.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = ({ renderCssLinks, renderJsBundles }) => {
+  return `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>routing</title>
+      <link href="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.min.css" rel="stylesheet">
+      <script async defer src="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.js"></script>
+      ${renderCssLinks()}
+    </head>
+    <body>
+      <div id="app"></div>
+      ${renderJsBundles()}
+    </body>
+    </html>
+  `;
+};

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -14,7 +14,7 @@ module.exports = ({ webpack, production }) => {
     stylesheets: [
       path.join(__dirname, './src/bg.css'),
     ],
-    htmlSource: path.join(__dirname, './src/index.html'),
+    htmlSource: path.join(__dirname, './src/html.js'),
     babelPlugins: [
       require.resolve('babel-plugin-lodash')
     ],

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const autoprefixer = require('autoprefixer');
 
-const postcssConcatenator = require('../packages/postcss-concatenator');
+const { concatToFile } = require('../packages/postcss-concatenator');
 const { CSS_BASENAME } = require('./constants');
 
 module.exports = {
@@ -15,7 +15,7 @@ function writeCss(urc) {
     return Promise.resolve();
   }
 
-  return postcssConcatenator({
+  return concatToFile({
     plugins: [
       autoprefixer({ browsers: urc.browserslist }), // TOFIX browserslist
       ...urc.postcssPlugins


### PR DESCRIPTION
This fixes the examples not running due to new API in [post-css plugin](https://github.com/mapbox/underreact/pull/12).

@davidtheclark for review. 