### PR TITLE
Add documentation for env

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Requirements:
 
 - Node 6+.
 
-Install Underreact as a dependency of your project:
+Install Underreact as a developer dependency of your project:
 
 ```
-npm install @mapbox/underreact
+npm install -D @mapbox/underreact
 ```
 
-Install the peer dependencies:
+If you are building a react application, you also need to install react dependencies:
 
 ```
 npm install react react-dom
@@ -38,46 +38,60 @@ Add `_underreact*` to your `.gitignore`, and maybe other ignore files (e.g. `.es
 
 **The bare minimum to get started with Underreact.**
 
-- Install Underreact and its peer dependencies.
-  ```
-  npm install @mapbox/underreact react react-dom
-  ```
-- Create a new `script` in your `package.json`:
-  ```json
-  "start": "underreact start",
-  ```
-- Create your entry JS file at `src/index.js`.
+- Create your entry JS file at `src/entry.js`.
 
-  ```js
-  import React from 'react';
-  import ReactDOM from 'react-dom';
+```js
+// src/entry.js
+console.log('hello world!');
+```
 
-  class App extends React.Component {
-    render() {
-      return <div>Hello world</div>;
-    }
-  }
+- Run it with `underreact`
 
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  ReactDOM.render('<App />', container);
-  ```
+```bash
+npx underreact start 
+# or 
+node node_modules/.bin/underreact start
+```
 
-- Run `npm run start`.
 - Open the URL printed in your terminal.
 
-Now you are up and running, ready to start building your website.
+**Using with react**
+
+- Create your entry JS file at `src/entry.js`.
+
+```jsx
+// src/entry.js
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+class App extends React.Component {
+  render() {
+    return <div>Hello world</div>;
+  }
+}
+
+const container = document.createElement('div');
+document.body.appendChild(container);
+ReactDOM.render(<App />, container);
+```
+
+- Run it with `underreact`
+
+```bash
+npx underreact start
+```
+
+- Open the URL printed in your terminal.
 
 ## Usage
 
-You should not install the Underreact CLI globally. Instead, install it as a dependency of your project and use the `underreact` command via npm `"scripts"`, `npx`, or `node_modules/.bin/underreact`. The easiest way is probably to set up npm scripts in `package.json`, so you can use `npm run start`, `npm run build`, etc., as needed.
+You should not install the Underreact CLI globally. Instead, install it as a dependency of your project and use the `underreact` command via  `npx`, npm `"scripts"`, or `node_modules/.bin/underreact`. The easiest way is probably to set up npm scripts in `package.json`, so you can use `npm run start`, `npm run build`, etc., as needed.
 
 The CLI provides the following commands:
 
 - `start`: Start a development server.
 - `build`: Build for deployment.
 - `serve-static`: Serve the files that you built for deployment.
-- `write-babelrc`: Write a `.bablerc` file.
 
 All commands look for `underreact.config.js` in the current working directory.
 
@@ -98,7 +112,7 @@ The function exported by your JS module will be passed a context object with the
 - `renderCssLinks`: **You must use this function to add CSS to the page,** unless your only sources of CSS are `<link>`s and `<style>`s that you write directly into your HTML. It will add CSS compiled from the [`stylesheets`] option and also any CSS that was created through other Webpack plugins you added.
 - `siteBasePath`: The [`siteBasePath`] you set in your configuration (or the default).
 - `publicAssetsPath`: The [`publicAssetsPath`] you set in your configuration (or the default).
-- `production`: Whether or not the HTML is being built for production. You may want to use this, for example, to decide whether or not to minify JS or CSS you are inlining into the HTML.
+- `production`: Whether or not the HTML is being built in production mode. You may want to use this, for example, to decide whether or not to minify JS or CSS you are inlining into the HTML.
 
 Here's an example of what an HTML-rendering module might look like:
 

--- a/bin/underreact.js
+++ b/bin/underreact.js
@@ -17,6 +17,10 @@ const middlewares = [
     if (!process.env.NODE_ENV) {
       process.env.NODE_ENV = argv.mode;
     }
+    if (!process.env.DEPLY_ENV) {
+      process.env.DEPLOY_ENV = argv.mode;
+    }
+
     // if the user specified a nonexistent path, tell them if it doesn't exist
     if (argv.config !== undefined && !fs.existsSync(argv.config)) {
       errorOut(

--- a/commands/build.js
+++ b/commands/build.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 
 const logger = require('../lib/logger');
 const autoCopy = require('../lib/utils/auto-copy');
+const { WEBPACK_ASSETS_BASENAME } = require('../lib/constants');
 const { writeHtml } = require('../lib/html-compiler');
 const { writeCss } = require('../lib/css-compiler');
 const {
@@ -37,7 +38,9 @@ function build(urc) {
       )
       // Clean up files you won't need to deploy.
       .then(() =>
-        del(path.join(urc.outputDirectory, 'assets.json'), { force: true })
+        del(path.join(urc.outputDirectory, WEBPACK_ASSETS_BASENAME), {
+          force: true
+        })
       )
       .then(() => {
         logger.log(chalk.green.bold('Finished building your site.'));

--- a/lib/config/__snapshots__/urc.test.js.snap
+++ b/lib/config/__snapshots__/urc.test.js.snap
@@ -4,7 +4,6 @@ exports[`getClientEnvVars doesnt leak internal vars 1`] = `
 Object {
   "DEPLOY_ENV": "test",
   "NODE_ENV": "test",
-  "PUBLIC_URL": "",
   "VISIBLE_TOKEN": "visible",
 }
 `;
@@ -14,7 +13,6 @@ Object {
   "DEPLOY_ENV": "test",
   "MY_APP_TOKEN": "visible",
   "NODE_ENV": "test",
-  "PUBLIC_URL": "",
 }
 `;
 

--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -75,10 +75,7 @@ module.exports = class Urc {
         // Most importantly, it switches React into the correct mode.
         NODE_ENV: process.env.NODE_ENV || this.mode,
         // Useful for providing a way to namespace different deployment targets
-        DEPLOY_ENV: process.env.DEPLOY_ENV || process.env.NODE_ENV || this.mode,
-        // Useful for resolving the correct path to static assets in `public`.
-        // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
-        PUBLIC_URL: this.siteBasePath
+        DEPLOY_ENV: process.env.DEPLOY_ENV || process.env.NODE_ENV || this.mode
       }
     );
 

--- a/lib/html-compiler.js
+++ b/lib/html-compiler.js
@@ -17,9 +17,13 @@ function renderHtml(urc, cssFilename) {
 
   const bundledScripts = [
     `<script>${uglifiedRuntime}</script>`,
-    `<script src="${assets.vendor.js}"></script>`,
     `<script src="${assets.main.js}"></script>`
   ];
+
+  // handles edge case when user doesn't import any module
+  if (assets.vendor && assets.vendor.js) {
+    bundledScripts.push(`<script src="${assets.vendor.js}"></script>`);
+  }
 
   const renderJsBundles = () => {
     return bundledScripts.join('\n');

--- a/lib/utils/get-dotenv-files.js
+++ b/lib/utils/get-dotenv-files.js
@@ -3,17 +3,17 @@ const path = require('path');
 const fs = require('fs');
 
 module.exports = function getDotenvFiles(rootDirectory = process.cwd()) {
-  const NODE_ENV = process.env.NODE_ENV;
+  const DEPLOY_ENV = process.env.DEPLOY_ENV || process.env.NODE_ENV;
   const dontenvPath = path.join(rootDirectory, '.env');
 
   // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
   const dotenvFiles = [
-    NODE_ENV && `${dontenvPath}.${NODE_ENV}.local`,
-    NODE_ENV && `${dontenvPath}.${NODE_ENV}`,
+    DEPLOY_ENV && `${dontenvPath}.${DEPLOY_ENV}.local`,
+    DEPLOY_ENV && `${dontenvPath}.${DEPLOY_ENV}`,
     // Don't include `.env.local` for `test` environment
     // since normally you expect tests to produce the same
     // results for everyone
-    NODE_ENV !== 'test' && `${dontenvPath}.local`,
+    DEPLOY_ENV !== 'test' && `${dontenvPath}.local`,
     dontenvPath
   ]
     .filter(Boolean)

--- a/lib/webpack-helpers/__snapshots__/create-webpack-config.test.js.snap
+++ b/lib/webpack-helpers/__snapshots__/create-webpack-config.test.js.snap
@@ -122,12 +122,10 @@ Object {
       "defaultValues": Object {
         "DEPLOY_ENV": "test",
         "NODE_ENV": "test",
-        "PUBLIC_URL": "/fancy",
       },
       "keys": Array [
         "NODE_ENV",
         "DEPLOY_ENV",
-        "PUBLIC_URL",
       ],
     },
     [Function],

--- a/lib/webpack-helpers/create-webpack-config.js
+++ b/lib/webpack-helpers/create-webpack-config.js
@@ -44,16 +44,23 @@ function createWebpackConfig(urc) {
     urc.jsEntry
   ].filter(Boolean);
 
+  const entry = {
+    main: mainEntry,
+    vendor: [
+      resolvePkg('react', { cwd: jsEntryDir }),
+      resolvePkg('react-dom', { cwd: jsEntryDir }),
+      ...urc.vendorModules
+    ].filter(Boolean)
+  };
+
+  // webpack complains if vendor is []
+  if (entry.vendor.length === 0) {
+    delete entry.vendor;
+  }
+
   const config = {
     mode: urc.production ? 'production' : 'development',
-    entry: {
-      main: mainEntry,
-      vendor: [
-        resolvePkg('react', { cwd: jsEntryDir }),
-        resolvePkg('react-dom', { cwd: jsEntryDir }),
-        ...urc.vendorModules
-      ].filter(Boolean)
-    },
+    entry,
     output: {
       path: path.join(urc.outputDirectory, urc.publicAssetsPath),
       publicPath: urlJoin(urc.siteBasePath, urc.publicAssetsPath),
@@ -102,7 +109,6 @@ function createWebpackConfig(urc) {
     bail: urc.production,
     performance: false
   };
-
   return urc.webpackConfigTransform(config);
 }
 


### PR DESCRIPTION
This adds documentation for the`dotenv` setup. It also makes some changes to accommodate using of `DEPLOY_ENV`.

@davidtheclark for review please.