### PR TITLE
Improve babel-preset-mapbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,8 +539,6 @@ Type: `Array<string>` \| `Object`. A valid [Browserslist](https://github.com/bro
 
 This value is used by Autoprefixer to set vendor prefixes in the CSS of your stylesheets, and is used to determine Babel compilation via [babel-preset-env](#babel).
 
-The default value uses Browserslist's default, which is `> 0.5%, last 2 versions, Firefox ESR, not dead`.
-
 You can also target different settings for different Underreact modes, by sending an object:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -28,13 +28,7 @@ It's a pretty thin wrapper around Babel, Webpack, and PostCSS, and will never ac
   - [publicDirectory](#publicdirectory)
   - [publicAssetsPath](#publicassetspath)
   - [port](#port)
-  - [postcssPlugins](#postcssplugins)
-  - [siteBasePath](#sitebasepath)
-  - [stylesheets](#stylesheets)
-  - [webpackLoaders](#webpackloaders)
-  - [webpackPlugins](#webpackplugins)
-  - [webpackConfigTransform](#webpackconfigtransform)
-  - [vendorModules](#vendormodules)
+  - [browserslist](#browserslist)
 
 ## Installation
 
@@ -347,6 +341,34 @@ module.exports = {
 
 ## Configuration Object Properties
 
+### browserslist
+
+Type: `Array<string>` \| `Object`. A valid [Browserslist](https://github.com/browserslist/browserslist) value. Default:`['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead']`.
+
+This value is used by Autoprefixer to set vendor prefixes in the CSS of your stylesheets, and is used to determine Babel compilation via [babel-preset-env](#babel).
+
+The default value uses Browserslist's default, which is `> 0.5%, last 2 versions, Firefox ESR, not dead`.
+
+You can also target different settings for different Underreact modes, by sending an object:
+
+```javascript
+// underreact.config.js
+{
+module.exports = {
+browserslist: {
+production: [
+'> 1%',
+'ie 10'
+],
+development: [
+'last 1 chrome version',
+'last 1 firefox version'
+]
+}
+}
+}
+```
+
 ### devServerHistoryFallback
 
 Type: `boolean`. Default: `false`.
@@ -467,11 +489,74 @@ Type: `config => transformedConfig`. Default `x => x` (identify function).
 If you want to make changes to the Webpack configuration beyond what's available in the above options, you can use this, the nuclear option.
 Your function receives the Webpack configuration that Underreact generates and returns a new Webpack configuration, representing your heart's desires.
 
-### vendorModules
+### jsEntry
 
-Type: `Array<string>`. Default: `[]`.
+Type: `string`. Absolute path, please. Default: `${project-directory}/src/index.js`.
 
-Identifiers of npm modules that you want to be added to the vendor bundle.
-The purpose of the vendor bundle is to deliberately group dependencies that change relatively infrequently — so this bundle will stay cached for longer than the others.
+The entry JS file for your app. Typically this is the file where you'll use `react-dom` to render your app on an element.
 
-By default, the vendor bundle includes `react` and `react-dom`.
+In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
+
+### outputDirectory
+
+Type `string`. Absolute path, please. Default: `${project-directory}/_underreact-site/`.
+
+The directory where files should be written.
+
+You'll want to ignore this directory with `.gitignore`, `.eslintignore`, etc.
+
+In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
+
+### publicDirectory
+
+Type `string`. Absolute path, please. Default: `${project-directory}/src/public/`.
+
+Any files you put into this directory will be copied, without processing, into the [outputDirectory](#outputdirectory).
+You can put images, favicons, data files, anything else you want in here.
+
+In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
+
+### publicAssetsPath
+
+Type: `string`. Default: `underreact-assets`.
+
+The directory where Underreact assets will be placed, relative to the site's root.
+
+By default, for example, the main JS chunk will be written to `underreact-assets/main.chunk.js`.
+
+It's important to know about this value so you can set up caching and other asset configuration on your server.
+
+### port
+
+Type: `number`. Default: `8080`.
+
+Preferred port for development servers.
+If the specified port is unavailable, another port is used.
+
+### browserslist
+
+Type: `Array<string>` \| `Object`. A valid [Browserslist](https://github.com/browserslist/browserslist) value. Default:`['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead']`.
+
+This value is used by Autoprefixer to set vendor prefixes in the CSS of your stylesheets, and is used to determine Babel compilation via [babel-preset-env](#babel).
+
+The default value uses Browserslist's default, which is `> 0.5%, last 2 versions, Firefox ESR, not dead`.
+
+You can also target different settings for different Underreact modes, by sending an object:
+
+```javascript
+// underreact.config.js
+{
+  module.exports = {
+    browserslist: {
+      production: [
+        '> 1%',
+        'ie 10'
+      ],
+      development: [
+        'last 1 chrome version',
+        'last 1 firefox version'
+      ]
+    }
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ It's a pretty thin wrapper around Babel, Webpack, and PostCSS, and will never ac
   - [Why not use NODE_ENV?](#why-not-use-node_env)
   - [Using environment variables inside underreact.config.js](#using-environment-variables-inside-underreactconfigjs)
 - [Underreact configuration file](#underreact-configuration-file)
-- [Configuration Object Properties](#configuration-object-properties)
+- [Configuration object properties](#configuration-object-properties)
+  - [browserslist](#browserslist)
   - [devServerHistoryFallback](#devserverhistoryfallback)
   - [htmlSource](#htmlsource)
   - [jsEntry](#jsentry)
@@ -28,7 +29,12 @@ It's a pretty thin wrapper around Babel, Webpack, and PostCSS, and will never ac
   - [publicDirectory](#publicdirectory)
   - [publicAssetsPath](#publicassetspath)
   - [port](#port)
-  - [browserslist](#browserslist)
+  - [postcssPlugins](#postcssplugins)
+  - [siteBasePath](#sitebasepath)
+  - [stylesheets](#stylesheets)
+  - [webpackLoaders](#webpackloaders)
+  - [webpackPlugins](#webpackplugins)
+  - [webpackConfigTransform](#webpackconfigtransform)
 
 ## Installation
 
@@ -339,7 +345,7 @@ module.exports = {
 }
 ```
 
-## Configuration Object Properties
+## Configuration object properties
 
 ### browserslist
 
@@ -353,19 +359,17 @@ You can also target different settings for different Underreact modes, by sendin
 
 ```javascript
 // underreact.config.js
-{
 module.exports = {
-browserslist: {
-production: [
-'> 1%',
-'ie 10'
-],
-development: [
-'last 1 chrome version',
-'last 1 firefox version'
-]
-}
-}
+  browserslist: {
+    production: [
+      '> 1%',
+      'ie 10'
+    ],
+    development: [
+      'last 1 chrome version',
+      'last 1 firefox version'
+    ]
+  }
 }
 ```
 
@@ -488,73 +492,3 @@ Type: `config => transformedConfig`. Default `x => x` (identify function).
 
 If you want to make changes to the Webpack configuration beyond what's available in the above options, you can use this, the nuclear option.
 Your function receives the Webpack configuration that Underreact generates and returns a new Webpack configuration, representing your heart's desires.
-
-### jsEntry
-
-Type: `string`. Absolute path, please. Default: `${project-directory}/src/index.js`.
-
-The entry JS file for your app. Typically this is the file where you'll use `react-dom` to render your app on an element.
-
-In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
-
-### outputDirectory
-
-Type `string`. Absolute path, please. Default: `${project-directory}/_underreact-site/`.
-
-The directory where files should be written.
-
-You'll want to ignore this directory with `.gitignore`, `.eslintignore`, etc.
-
-In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
-
-### publicDirectory
-
-Type `string`. Absolute path, please. Default: `${project-directory}/src/public/`.
-
-Any files you put into this directory will be copied, without processing, into the [outputDirectory](#outputdirectory).
-You can put images, favicons, data files, anything else you want in here.
-
-In the default value, `project-directory` refers to the directory of your `underreact.config.js` file, or the current working directory.
-
-### publicAssetsPath
-
-Type: `string`. Default: `underreact-assets`.
-
-The directory where Underreact assets will be placed, relative to the site's root.
-
-By default, for example, the main JS chunk will be written to `underreact-assets/main.chunk.js`.
-
-It's important to know about this value so you can set up caching and other asset configuration on your server.
-
-### port
-
-Type: `number`. Default: `8080`.
-
-Preferred port for development servers.
-If the specified port is unavailable, another port is used.
-
-### browserslist
-
-Type: `Array<string>` \| `Object`. A valid [Browserslist](https://github.com/browserslist/browserslist) value. Default:`['> 0.5%', 'last 2 versions', 'Firefox ESR', 'not dead']`.
-
-This value is used by Autoprefixer to set vendor prefixes in the CSS of your stylesheets, and is used to determine Babel compilation via [babel-preset-env](#babel).
-
-You can also target different settings for different Underreact modes, by sending an object:
-
-```javascript
-// underreact.config.js
-{
-  module.exports = {
-    browserslist: {
-      production: [
-        '> 1%',
-        'ie 10'
-      ],
-      development: [
-        'last 1 chrome version',
-        'last 1 firefox version'
-      ]
-    }
-  }
-}
-```

--- a/bin/underreact.js
+++ b/bin/underreact.js
@@ -15,10 +15,10 @@ const getCliOpts = require('../lib/utils/get-cli-opts');
 const middlewares = [
   argv => {
     if (!process.env.NODE_ENV) {
-      process.env.NODE_ENV = argv.mode;
+      process.env.NODE_ENV = argv.mode || 'production';
     }
     if (!process.env.DEPLOY_ENV) {
-      process.env.DEPLOY_ENV = argv.mode;
+      process.env.DEPLOY_ENV = argv.mode || 'production';
     }
 
     // if the user specified a nonexistent path, tell them if it doesn't exist

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -41,6 +41,16 @@ module.exports = ({ webpack, production }) => {
     webpackConfigTransform: config => {
       config.devtool = false;
       return config;
+    },
+    "browserslist": {
+      "production": [
+        "> 1%",
+        "ie 10"
+      ],
+      "development": [
+        "last 1 chrome version",
+        "last 1 firefox version"
+      ]
     }
   };
 };

--- a/lib/config/__snapshots__/urc.test.js.snap
+++ b/lib/config/__snapshots__/urc.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getClientEnvVars doesnt leak internal vars 1`] = `
+exports[`getClientEnvVars doesn't leak internal vars 1`] = `
 Object {
   "DEPLOY_ENV": "test",
   "NODE_ENV": "test",

--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -113,14 +113,34 @@ module.exports = class Urc {
     return result;
   }
 
+  getBrowserslist() {
+    if (!this.browserslist) {
+      return;
+    }
+
+    let query;
+
+    if (Array.isArray(this.browserslist)) {
+      query = this.browserslist;
+    }
+    // handle the case when passed an object to target `production`||`deployment` envs.
+    else if (Array.isArray(this.browserslist[process.env.NODE_ENV])) {
+      query = this.browserslist[process.env.NODE_ENV];
+    }
+
+    if (query) {
+      return browserslist(query, {
+        env: process.env.NODE_ENV ? 'production' : 'development'
+      });
+    }
+  }
+
   // Due to the limitation of babel-preset-env v6 not being able to
   // read browserslist https://github.com/babel/babel-preset-env/issues/149
   // This sets up the process.env.BROWSERSLIST which is then read by babel-preset-mapbox
-  // so that it can then use pass it to `babel-preset-env`.
+  // so that it can then pass it to `babel-preset-env`.
   setBrowserslistEnv() {
-    const list = browserslist(this.browserslist, {
-      env: process.env.NODE_ENV ? 'production' : 'development'
-    });
+    const list = this.getBrowserslist();
     if (Array.isArray(list) && list.length > 0) {
       process.env.BROWSERSLIST = list.join(',');
     }

--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -4,6 +4,7 @@ const path = require('path');
 const _ = require('lodash');
 const fs = require('fs');
 const dotenv = require('dotenv');
+const browserslist = require('browserslist');
 
 const dynamicRequire = require('../utils/dynamic-require');
 const getDotenvFiles = require('../utils/get-dotenv-files');
@@ -25,6 +26,8 @@ module.exports = class Urc {
       urc.publicAssetsPath = '/' + urc.publicAssetsPath;
     }
     Object.assign(this, urc);
+
+    this.setBrowserslistEnv();
   }
 
   getAssets() {
@@ -108,5 +111,18 @@ module.exports = class Urc {
     );
 
     return result;
+  }
+
+  // Due to the limitation of babel-preset-env v6 not being able to
+  // read browserslist https://github.com/babel/babel-preset-env/issues/149
+  // This sets up the process.env.BROWSERSLIST which is then read by babel-preset-mapbox
+  // so that it can then use pass it to `babel-preset-env`.
+  setBrowserslistEnv() {
+    const list = browserslist(this.browserslist, {
+      env: process.env.NODE_ENV ? 'production' : 'development'
+    });
+    if (Array.isArray(list) && list.length > 0) {
+      process.env.BROWSERSLIST = list.join(',');
+    }
   }
 };

--- a/lib/config/validate-config.js
+++ b/lib/config/validate-config.js
@@ -32,7 +32,7 @@ function validateConfig(rawConfig = {}) {
         }),
         stats: v.string,
         clientEnvPrefix: v.string,
-        browserslist: v.oneOf(v.arrayOf(v.string), v.plainObject)
+        browserslist: v.oneOfType(v.plainObject, v.arrayOf(v.string))
       })
     )(rawConfig);
   } catch (error) {

--- a/lib/config/validate-config.js
+++ b/lib/config/validate-config.js
@@ -31,7 +31,8 @@ function validateConfig(rawConfig = {}) {
           fetch: v.boolean
         }),
         stats: v.string,
-        clientEnvPrefix: v.string
+        clientEnvPrefix: v.string,
+        browserslist: v.oneOf(v.arrayOf(v.string), v.plainObject)
       })
     )(rawConfig);
   } catch (error) {

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -22,7 +22,7 @@ function writeCss(urc) {
   );
   return concatToFile({
     plugins: [
-      autoprefixer({ browsers: urc.browserslist }), // TOFIX browserslist
+      autoprefixer({ browsers: urc.browserslist }),
       ...urc.postcssPlugins
     ],
     stylesheets: urc.stylesheets,

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -22,7 +22,7 @@ function writeCss(urc) {
   );
   return concatToFile({
     plugins: [
-      autoprefixer({ browsers: urc.browserslist }),
+      autoprefixer({ browsers: urc.getBrowserslist() }),
       ...urc.postcssPlugins
     ],
     stylesheets: urc.stylesheets,

--- a/lib/webpack-helpers/__snapshots__/create-webpack-config.test.js.snap
+++ b/lib/webpack-helpers/__snapshots__/create-webpack-config.test.js.snap
@@ -29,6 +29,7 @@ Object {
             "options": Object {
               "babelrc": false,
               "cacheDirectory": true,
+              "cacheIdentifier": "{\\"babel-loader\\":\\"7.1.5\\",\\"babel-core\\":\\"6.26.3\\",\\"babelrc\\":\\"\\",\\"env\\":\\"test\\"}",
               "compact": false,
               "presets": Array [
                 "<PROJECT_ROOT>/packages/babel-preset-mapbox/index.js",

--- a/lib/webpack-helpers/create-webpack-config.js
+++ b/lib/webpack-helpers/create-webpack-config.js
@@ -113,16 +113,29 @@ function createWebpackConfig(urc) {
 }
 
 function createBabelLoader(urc) {
+  const babelrcPath = path.join(urc.rootDirectory, '.babelrc');
+  const exists = fs.existsSync(babelrcPath);
+
   const loader = {
     loader: require.resolve('babel-loader'),
     options: {
       presets: [require.resolve('../../packages/babel-preset-mapbox')],
-      cacheDirectory: true,
       babelrc: false,
-      compact: false
+      compact: false,
+      cacheDirectory: true,
+      // `babel-preset-mapbox` depends on the `process.env.BROWSERSLIST` and
+      // any change it its value would fail to change the default `cacheIdentifier` of `babel-loader`
+      // hence leading to stale babel output. To mitigate this we need to create a more accurate `cacheIdentifier`
+      // which is (`defaultCacheIdentifier` + `urc.browserslist`) ref: https://github.com/babel/babel-loader/blob/7.x/src/index.js#L129
+      cacheIdentifier: JSON.stringify({
+        'babel-loader': require('babel-loader/package.json').version,
+        'babel-core': require('babel-core/package.json').version,
+        babelrc: exists ? fs.readFileSync(babelrcPath, 'utf8') : '',
+        env: process.env.BABEL_ENV || process.env.NODE_ENV || 'development',
+        browserslist: urc.browserslist
+      })
     }
   };
-  const exists = fs.existsSync(path.join(urc.rootDirectory, '.babelrc'));
 
   if (exists) {
     delete loader.options.presets;

--- a/lib/webpack-helpers/create-webpack-config.test.js
+++ b/lib/webpack-helpers/create-webpack-config.test.js
@@ -42,7 +42,7 @@ test('Basic Test', () => {
   expect(createConfig(urc)).toMatchSnapshot();
 });
 
-test('uses babelrc if it exists at project root', () => {
+test('Uses babelrc if it exists at project root', () => {
   const tempDir = tempy.directory();
   const defaultConfig = getDefaultConfig({
     mode: 'development',
@@ -67,7 +67,7 @@ test('uses babelrc if it exists at project root', () => {
   ]);
 });
 
-test('uses babel preset if babelrc doesnt exists at project root', () => {
+test('Uses babel preset if babelrc doesnt exists at project root', () => {
   const tempDir = tempy.directory();
   const defaultConfig = getDefaultConfig({
     mode: 'development',
@@ -87,6 +87,32 @@ test('uses babel preset if babelrc doesnt exists at project root', () => {
         cacheDirectory: true,
         babelrc: false,
         compact: false
+      }
+    }
+  ]);
+});
+
+test('babel-loader creates a good cacheIdentifier which includes urc.browserslist', () => {
+  const defaultConfig = getDefaultConfig({
+    mode: 'development',
+    configPath: '/fake/underreact.config.js'
+  });
+
+  const browserslist = 'last 2 versions';
+  const urc = new Urc({ browserslist: [browserslist] }, defaultConfig);
+
+  expect(
+    createConfig(urc).module.rules.find(
+      obj => obj.test.toString() === `/\\.jsx?$/`
+    ).use
+  ).toMatchObject([
+    {
+      loader: require.resolve('babel-loader'),
+      options: {
+        cacheDirectory: true,
+        babelrc: false,
+        compact: false,
+        cacheIdentifier: expect.stringMatching(browserslist)
       }
     }
   ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
       "dev": true
     },
     "@mapbox/fusspot": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.2.1.tgz",
-      "integrity": "sha1-fsZmyzYmSVVC9m8XFdoF7mQnwaA=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/fusspot/-/fusspot-0.4.0.tgz",
+      "integrity": "sha512-6sys1vUlhNCqMvJOqPEPSi0jc9tg7aJ//oG1A16H3PXoIt9whtNngD7UzBHUVTH15zunR/vRvMtGNVsogm1KzA==",
       "requires": {
         "is-plain-obj": "^1.1.0",
         "xtend": "^4.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -642,6 +642,15 @@
         "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
         "caniuse-lite": {
           "version": "1.0.30000861",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000861.tgz",
@@ -1123,12 +1132,13 @@
       }
     },
     "browserslist": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+      "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
       "requires": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
+        "caniuse-lite": "^1.0.30000876",
+        "electron-to-chromium": "^1.3.57",
+        "node-releases": "^1.0.0-alpha.11"
       }
     },
     "bser": {
@@ -1254,9 +1264,9 @@
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "caniuse-lite": {
-      "version": "1.0.30000856",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-      "integrity": "sha512-x3mYcApHMQemyaHuH/RyqtKCGIYTgEA63fdi+VBvDz8xUSmRiVWTLeyKcoGQCGG6UPR9/+4qG4OKrTa6aSQRKg=="
+      "version": "1.0.30000876",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000876.tgz",
+      "integrity": "sha512-v+Q2afhJJ1oydQnEB4iHhxDz5x9lWPbRnQBQlM3FgtZxqLO8KDSdu4txUrFwC1Ws9I2kQi/QImkvj17NbVpNAg=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -2141,9 +2151,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.50",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
-      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc="
+      "version": "1.3.58",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz",
+      "integrity": "sha512-AGJxlBEn2wOohxqWZkISVsOjZueKTQljfEODTDSEiMqSpH0S+xzV+/5oEM9AGaqhu7DzrpKOgU7ocQRjj0nJmg=="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -6917,6 +6927,14 @@
         "which": "^1.3.0"
       }
     },
+    "node-releases": {
+      "version": "1.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+      "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
+      "requires": {
+        "semver": "^5.3.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -8532,8 +8550,7 @@
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
-      "dev": true
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "^15.0.0"
   },
   "dependencies": {
-    "@mapbox/fusspot": "^0.2.1",
+    "@mapbox/fusspot": "^0.4.0",
     "address": "^1.0.3",
     "assets-webpack-plugin": "^3.8.4",
     "autoprefixer": "^8.6.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "autoprefixer": "^8.6.4",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.5",
+    "browserslist": "^4.0.2",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.4",
     "concat-with-sourcemaps": "^1.1.0",

--- a/packages/babel-preset-mapbox/README.md
+++ b/packages/babel-preset-mapbox/README.md
@@ -49,33 +49,37 @@ Then create a `.babelrc` at the root of your project:
 
 ### Modifying browser support with the help of `browserslist`
 
-`babel-preset-mapbox` uses [babel-preset-env](https://www.npmjs.com/package/babel-preset-env) internally to compile ES2015+ Javascript to older Javascript. You can customize the amount of compilation done by giving a list of browsers you want to support. We use [browserslist](https://github.com/ai/browserslist) to parse this information, so you can use [any valid query format supported by browserslist](https://github.com/ai/browserslist#queries).
+You can customize the amount of compilation done by giving a list of browsers you want to support. We use [browserslist](https://github.com/ai/browserslist) to parse this information, so you can use [any valid query format supported by browserslist](https://github.com/ai/browserslist#queries).
+
+`@mapbox/babel-preset-mapbox` allows you to customize [browserslist](https://github.com/ai/browserslist) by setting the environment variable `BROWSERSLIST`. You can set it directly in your shell before running Babel:
+
+```bash
+export BROWSERSLIST=">0.25%, not ie 11"
+npx babel script.js
+```
+
+Make sure your `.babelrc` files includes the `@mapbox/babel-preset-mapbox` preset:
 
 ```
+// .babelrc
 {
   "presets": [
-    "@mapbox/babel-preset-mapbox", {
-      browserslist: [">0.25%", "not ie 11", "not op_mini all"]
-    }
+    "@mapbox/babel-preset-mapbox"
   ]
 }
 ```
 
-### Different configuration with node environment
+**Note:** Using [babel-preset-env](https://www.npmjs.com/package/babel-preset-env) along with `BROWSERSLIST` environment variable would throw an **error** to avoid ambiguity between coexisting `browserslist` value. You should instead just set the environment variable `BROWSERSLIST`. If your use case doesn't allow for this, please feel free to open a ticket about it.
 
-If you want to have a different configuration for each node environments, for e.g. `production`, `test` or `development`, you can configure your `.babelrc` accordingly. In the example below, we are overriding the `browserslist` to target only Chrome for development environment. For more information visit [babelrc](https://babeljs.io/docs/en/babelrc).
+You can also set the `BROWSERSLIST` environment variable in your node application before parsing code with Babel and `"@mapbox/babel-preset-mapbox"`:
 
-```
-{
-  "env": {
-    "production": {
-      "presets": ["@mapbox/babel-preset-mapbox"],
-    },
-    "development": {
-      "presets": ["@mapbox/babel-preset-mapbox", {
-        browserslist: ["last 2 Chrome versions"]
-      }]
-    }
-  }
-}
+```js
+const babel = require('babel-core');
+
+process.env.BROWSERSLIST = ">0.25%, not ie 11";
+
+babel.transform(code, {
+    presets: [require.resolve('@mapbox/babel-preset-mapbox')],
+    filename: 'source.js'
+}).code;
 ```

--- a/packages/babel-preset-mapbox/README.md
+++ b/packages/babel-preset-mapbox/README.md
@@ -69,8 +69,6 @@ Make sure your `.babelrc` files includes the `@mapbox/babel-preset-mapbox` prese
 }
 ```
 
-**Note:** Using [babel-preset-env](https://www.npmjs.com/package/babel-preset-env) along with `BROWSERSLIST` environment variable would throw an **error** to avoid ambiguity between coexisting `browserslist` value. You should instead just set the environment variable `BROWSERSLIST`. If your use case doesn't allow for this, please feel free to open a ticket about it.
-
 You can also set the `BROWSERSLIST` environment variable in your node application before parsing code with Babel and `"@mapbox/babel-preset-mapbox"`:
 
 ```js
@@ -83,3 +81,5 @@ babel.transform(code, {
     filename: 'source.js'
 }).code;
 ```
+
+**Note:** Please avoid using [babel-preset-env](https://www.npmjs.com/package/babel-preset-env) to define your browser support. Using it would throw an **error** to avoid conflicting with the `BROWSERSLIST` env var. You should instead just set the value of environment variable `BROWSERSLIST`. If your use case doesn't allow for this, please feel free to open a ticket about it.

--- a/packages/babel-preset-mapbox/README.md
+++ b/packages/babel-preset-mapbox/README.md
@@ -1,0 +1,81 @@
+# @mapbox/babel-preset-mapbox
+
+A configurable Babel preset which abstracts away the most common Babel plugins and presets needed to build a modern web application.
+
+## Usage
+
+Install `babel-preset-mapbox` by running the following command at the root of your project:
+
+```npm
+npm install --save-dev @mapbox/babel-preset-mapbox
+```
+
+Then create a `.babelrc` at the root of your project:
+
+```
+// .babelrc
+{
+  "presets": ["@mapbox/babel-preset-mapbox"]
+}
+```
+
+### Configuration
+
+`babel-preset-mapbox` is a simple wrapper around a bunch of Babel presets and plugins. You can customize each of the [babel preset/plugin](#which-babel-preset-and-plugin-does-it-use), by passing an object with keys and values representing the name and configuration of preset/plugin respectively. In the example below, we are overriding the defaults of `transform-react-jsx`:
+
+```
+{
+  "presets": ["@mapbox/babel-preset-mapbox", {
+    'transform-react-jsx': {
+      pragma: 'dom'
+    }
+  }]
+}
+```
+
+## Which Babel preset and plugin does it use?
+
+- [babel-plugin-dynamic-import-node](https://www.npmjs.com/package/babel-plugin-dynamic-import-node)
+- [babel-plugin-syntax-dynamic-import](https://www.npmjs.com/package/babel-plugin-syntax-dynamic-import)
+- [babel-plugin-transform-class-properties](https://www.npmjs.com/package/babel-plugin-transform-class-properties)
+- [babel-plugin-transform-es2015-destructuring](https://www.npmjs.com/package/babel-plugin-transform-es2015-destructuring)
+- [babel-plugin-transform-object-rest-spread](https://www.npmjs.com/package/babel-plugin-transform-object-rest-spread)
+- [babel-plugin-transform-react-jsx-self](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-self)
+- [babel-plugin-transform-react-jsx-source](https://www.npmjs.com/package/babel-plugin-transform-react-jsx-source)
+- [babel-plugin-transform-react-remove-prop-types](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types)
+- [babel-plugin-transform-runtime](https://www.npmjs.com/package/babel-plugin-transform-runtime)
+- [babel-preset-env](https://www.npmjs.com/package/babel-preset-env)
+- [babel-preset-react](https://www.npmjs.com/package/babel-preset-react)
+
+### Modifying browser support with the help of `browserslist`
+
+`babel-preset-mapbox` uses [babel-preset-env](https://www.npmjs.com/package/babel-preset-env) internally to compile ES2015+ Javascript to older Javascript. You can customize the amount of compilation done by giving a list of browsers you want to support. We use [browserslist](https://github.com/ai/browserslist) to parse this information, so you can use [any valid query format supported by browserslist](https://github.com/ai/browserslist#queries).
+
+```
+{
+  "presets": [
+    "@mapbox/babel-preset-mapbox", {
+      browserslist: [">0.25%", "not ie 11", "not op_mini all"]
+    }
+  ]
+}
+```
+
+### Different configuration with node environment
+
+If you want to have a different configuration for each node environments, for e.g. `production`, `test` or `development`, you can configure your `.babelrc` accordingly. In the example below, we are overriding the `browserslist` to target only Chrome for development environment. For more information visit [babelrc](https://babeljs.io/docs/en/babelrc).
+
+```
+{
+  "env": {
+    "production": {
+      "presets": ["@mapbox/babel-preset-mapbox"],
+    },
+    "development": {
+      "presets": ["@mapbox/babel-preset-mapbox", {
+        browserslist: ["last 2 Chrome versions"]
+      }]
+    }
+  }
+}
+```

--- a/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
@@ -1,0 +1,245 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Applies options correctly to internal plugins and presets 1`] = `
+"\\"use strict\\";
+
+var _jsxFileName = \\"test\\";
+const F = () => dom(Zoo, {
+  __source: {
+    fileName: _jsxFileName,
+    lineNumber: 1
+  },
+  __self: undefined
+});"
+`;
+
+exports[`Browserslist doesnt get injected in test env  1`] = `
+Array [
+  "babel-preset-react",
+  Array [
+    "babel-preset-env",
+    Object {
+      "targets": Object {
+        "node": "current",
+      },
+    },
+  ],
+]
+`;
+
+exports[`Passes opts correctly 1`] = `
+Object {
+  "plugins": Array [
+    "babel-plugin-transform-es2015-destructuring",
+    Array [
+      "babel-plugin-transform-class-properties",
+      Object {
+        "xyz": "123",
+      },
+    ],
+    Array [
+      "babel-plugin-transform-object-rest-spread",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-react-jsx",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-runtime",
+      Object {
+        "helpers": false,
+        "polyfill": false,
+        "regenerator": true,
+      },
+    ],
+    "babel-plugin-dynamic-import-node",
+    "babel-plugin-transform-react-jsx-source",
+    "babel-plugin-transform-react-jsx-self",
+  ],
+  "presets": Array [
+    Array [
+      "babel-preset-react",
+      Object {
+        "abc": "def",
+      },
+    ],
+    Array [
+      "babel-preset-env",
+      Object {
+        "targets": Object {
+          "node": "current",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`Right order of configuration in development 1`] = `
+Object {
+  "plugins": Array [
+    "babel-plugin-transform-es2015-destructuring",
+    "babel-plugin-transform-class-properties",
+    Array [
+      "babel-plugin-transform-object-rest-spread",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-react-jsx",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-runtime",
+      Object {
+        "helpers": false,
+        "polyfill": false,
+        "regenerator": true,
+      },
+    ],
+    "babel-plugin-syntax-dynamic-import",
+    "babel-plugin-transform-react-jsx-source",
+    "babel-plugin-transform-react-jsx-self",
+  ],
+  "presets": Array [
+    "babel-preset-react",
+    Array [
+      "babel-preset-env",
+      Object {
+        "modules": false,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`Right order of configuration in production 1`] = `
+Object {
+  "plugins": Array [
+    "babel-plugin-transform-es2015-destructuring",
+    "babel-plugin-transform-class-properties",
+    Array [
+      "babel-plugin-transform-object-rest-spread",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-react-jsx",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-runtime",
+      Object {
+        "helpers": false,
+        "polyfill": false,
+        "regenerator": true,
+      },
+    ],
+    "babel-plugin-syntax-dynamic-import",
+    "babel-plugin-transform-react-remove-prop-types",
+  ],
+  "presets": Array [
+    "babel-preset-react",
+    Array [
+      "babel-preset-env",
+      Object {
+        "modules": false,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`Right order of configuration in test 1`] = `
+Object {
+  "plugins": Array [
+    "babel-plugin-transform-es2015-destructuring",
+    "babel-plugin-transform-class-properties",
+    Array [
+      "babel-plugin-transform-object-rest-spread",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-react-jsx",
+      Object {
+        "useBuiltIns": true,
+      },
+    ],
+    Array [
+      "babel-plugin-transform-runtime",
+      Object {
+        "helpers": false,
+        "polyfill": false,
+        "regenerator": true,
+      },
+    ],
+    "babel-plugin-dynamic-import-node",
+    "babel-plugin-transform-react-jsx-source",
+    "babel-plugin-transform-react-jsx-self",
+  ],
+  "presets": Array [
+    "babel-preset-react",
+    Array [
+      "babel-preset-env",
+      Object {
+        "targets": Object {
+          "node": "current",
+        },
+      },
+    ],
+  ],
+}
+`;
+
+exports[`Throws error when incorrect options are provided 1`] = `"\`@mapbox/babel-preset-mapbox\` expects an object as an option. (While processing preset: \\"<PROJECT_ROOT>/packages/babel-preset-mapbox/index.js\\")"`;
+
+exports[`Works with React 1`] = `
+"'use strict';
+
+var _jsxFileName = 'test';
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const F = () => _react2.default.createElement(Zoo, {
+        __source: {
+                fileName: _jsxFileName,
+                lineNumber: 3
+        },
+        __self: undefined
+});"
+`;
+
+exports[`browserslist property works in non test env  1`] = `
+Array [
+  "babel-preset-react",
+  Array [
+    "babel-preset-env",
+    Object {
+      "targets": Object {
+        "browsers": Array [
+          ">0.25%",
+          "not ie 11",
+          "not op_mini all",
+        ],
+      },
+    },
+  ],
+]
+`;

--- a/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
@@ -33,6 +33,7 @@ Array [
   Array [
     "babel-preset-env",
     Object {
+      "modules": false,
       "targets": Object {
         "browsers": ">0.25%,not ie 11,not op_mini all",
       },

--- a/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
+++ b/packages/babel-preset-mapbox/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ const F = () => dom(Zoo, {
 });"
 `;
 
-exports[`Browserslist doesnt get injected in test env  1`] = `
+exports[`BROWSERSLIST env var doesn't get injected in test env  1`] = `
 Array [
   "babel-preset-react",
   Array [
@@ -21,6 +21,20 @@ Array [
     Object {
       "targets": Object {
         "node": "current",
+      },
+    },
+  ],
+]
+`;
+
+exports[`BROWSERSLIST env var works in non test env  1`] = `
+Array [
+  "babel-preset-react",
+  Array [
+    "babel-preset-env",
+    Object {
+      "targets": Object {
+        "browsers": ">0.25%,not ie 11,not op_mini all",
       },
     },
   ],
@@ -224,22 +238,4 @@ const F = () => _react2.default.createElement(Zoo, {
         },
         __self: undefined
 });"
-`;
-
-exports[`browserslist property works in non test env  1`] = `
-Array [
-  "babel-preset-react",
-  Array [
-    "babel-preset-env",
-    Object {
-      "targets": Object {
-        "browsers": Array [
-          ">0.25%",
-          "not ie 11",
-          "not op_mini all",
-        ],
-      },
-    },
-  ],
-]
 `;

--- a/packages/babel-preset-mapbox/index.js
+++ b/packages/babel-preset-mapbox/index.js
@@ -95,10 +95,8 @@ module.exports = function preset(context, opts) {
       }
     };
     if (process.env.BROWSERSLIST) {
-      presetEnv.options = {
-        targets: {
-          browsers: process.env.BROWSERSLIST
-        }
+      presetEnv.options.targets = {
+        browsers: process.env.BROWSERSLIST
       };
     }
 

--- a/packages/babel-preset-mapbox/index.js
+++ b/packages/babel-preset-mapbox/index.js
@@ -25,14 +25,13 @@ module.exports = function preset(context, opts) {
       '`@mapbox/babel-preset-mapbox` expects an object as an option.'
     );
   }
-
   // prevent ambiguity if user is using both
   if (
-    (opts.browserslist && opts['babel-preset-env']) ||
-    (opts.browserslist && opts['env'])
+    (process.env.BROWSERSLIST && opts['babel-preset-env']) ||
+    (process.env.BROWSERSLIST && opts['env'])
   ) {
     throw new Error(
-      'Please do not provide `browserslist` and `babel-preset-env` together, instead just use `browserslist`.'
+      'Please do not use process.env.BROWSERSLIST and `babel-preset-env` together.'
     );
   }
 
@@ -95,10 +94,10 @@ module.exports = function preset(context, opts) {
         modules: false
       }
     };
-    if (opts.browserslist) {
+    if (process.env.BROWSERSLIST) {
       presetEnv.options = {
         targets: {
-          browsers: opts.browserslist
+          browsers: process.env.BROWSERSLIST
         }
       };
     }

--- a/packages/babel-preset-mapbox/index.js
+++ b/packages/babel-preset-mapbox/index.js
@@ -136,14 +136,7 @@ module.exports = function preset(context, opts) {
 };
 
 function findProperty(data, name) {
-  if (data[name]) {
-    return data[name];
-  }
-  // NOTE: babel-preset & babel-plugin have same length
-  const len = 'babel-preset-'.length;
-  // If the user used a shorthand for eg. dynamic-import-node instead of babel-plugin-dynamic-import-node
-  // remove `babel-*-` and then try to find it.
-  return data[name.substring(len)];
+  return data[name] || data[name.replace(/^babel-(preset|plugin)-/, '')];
 }
 
 function filterOutPlugins(payload) {

--- a/packages/babel-preset-mapbox/index.test.js
+++ b/packages/babel-preset-mapbox/index.test.js
@@ -54,29 +54,34 @@ test('Passes opts correctly', () => {
   expect(config).toMatchSnapshot();
 });
 
-test('browserslist property works in non test env ', () => {
+test('BROWSERSLIST env var works in non test env ', () => {
   process.env.BABEL_ENV = 'development';
-  const config = preset(null, {
-    browserslist: ['>0.25%', 'not ie 11', 'not op_mini all']
-  });
+  process.env.BROWSERSLIST = ['>0.25%', 'not ie 11', 'not op_mini all'].join(
+    ','
+  );
+  const config = preset(null);
   expect(config.presets).toMatchSnapshot();
   delete process.env.BABEL_ENV;
+  delete process.env.BROWSERSLIST;
 });
 
-test('Throws error when both browserslist and env are provided ', () => {
+test('Throws error when both BROWSERSLIST and babel-preset-env are provided ', () => {
+  process.env.BROWSERSLIST = 'something';
   expect(() =>
     preset(null, {
-      browserslist: ['>0.25%', 'not ie 11', 'not op_mini all'],
       'babel-preset-env': {}
     })
   ).toThrowError();
+  delete process.env.BROWSERSLIST;
 });
 
-test('Browserslist doesnt get injected in test env ', () => {
-  const config = preset(null, {
-    browserslist: ['>0.25%', 'not ie 11', 'not op_mini all']
-  });
+test("BROWSERSLIST env var doesn't get injected in test env ", () => {
+  process.env.BROWSERSLIST = ['>0.25%', 'not ie 11', 'not op_mini all'].join(
+    ','
+  );
+  const config = preset(null);
   expect(config.presets).toMatchSnapshot();
+  delete process.env.BROWSERSLIST;
 });
 
 test('Works with React', () => {

--- a/packages/babel-preset-mapbox/index.test.js
+++ b/packages/babel-preset-mapbox/index.test.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const babel = require('babel-core');
+
+const preset = require('./index.js');
+
+const transform = (code, options) =>
+  babel.transform(code, {
+    presets: [[require.resolve('./index.js'), options]],
+    // This is needed 'babel-plugin-transform-react-jsx-source' throws an error without a filename
+    filename: 'test'
+  }).code;
+
+test('Right order of configuration in production', () => {
+  process.env.BABEL_ENV = 'production';
+  expect(preset()).toMatchSnapshot();
+  delete process.env.BABEL_ENV;
+});
+
+test('Right order of configuration in development', () => {
+  process.env.BABEL_ENV = 'development';
+  expect(preset()).toMatchSnapshot();
+  delete process.env.BABEL_ENV;
+});
+
+test('Right order of configuration in test', () => {
+  process.env.BABEL_ENV = 'test';
+  expect(preset()).toMatchSnapshot();
+  delete process.env.BABEL_ENV;
+});
+
+test('Passes opts correctly', () => {
+  const config = preset(null, {
+    'babel-preset-react': {
+      abc: 'def'
+    },
+    'non-existent': {
+      a: 'a'
+    },
+    'transform-class-properties': { xyz: '123' }
+  });
+  expect(config.presets).toContainEqual([
+    'babel-preset-react',
+    {
+      abc: 'def'
+    }
+  ]);
+  expect(config.plugins).toContainEqual([
+    'babel-plugin-transform-class-properties',
+    {
+      xyz: '123'
+    }
+  ]);
+  expect(config).toMatchSnapshot();
+});
+
+test('browserslist property works in non test env ', () => {
+  process.env.BABEL_ENV = 'development';
+  const config = preset(null, {
+    browserslist: ['>0.25%', 'not ie 11', 'not op_mini all']
+  });
+  expect(config.presets).toMatchSnapshot();
+  delete process.env.BABEL_ENV;
+});
+
+test('Throws error when both browserslist and env are provided ', () => {
+  expect(() =>
+    preset(null, {
+      browserslist: ['>0.25%', 'not ie 11', 'not op_mini all'],
+      'babel-preset-env': {}
+    })
+  ).toThrowError();
+});
+
+test('Browserslist doesnt get injected in test env ', () => {
+  const config = preset(null, {
+    browserslist: ['>0.25%', 'not ie 11', 'not op_mini all']
+  });
+  expect(config.presets).toMatchSnapshot();
+});
+
+test('Works with React', () => {
+  expect(
+    transform(`
+        import React from 'react';
+        const F = () => <Zoo/>;
+    `)
+  ).toMatchSnapshot();
+});
+
+test('Throws error when incorrect options are provided', () => {
+  expect(() => transform(``, 45)).toThrowErrorMatchingSnapshot();
+});
+
+test('Applies options correctly to internal plugins and presets', () => {
+  expect(
+    transform(`const F = () => <Zoo/>;`, {
+      'transform-react-jsx': {
+        pragma: 'dom'
+      }
+    })
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
This PR allows :
- `babel-preset-mapbox` now only accept an object as an option.
- Accepts `browserslist`, which then gets injected into `preset-env`.
- Adds some tests to lock the functionality.
- Improves documentation of the preset.

@davidtheclark for review, please.