### PR TITLE
FIx default html.js 

### DIFF
--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -34,6 +34,17 @@ module.exports = class Urc {
     });
   }
 
+  getRuntimeJs() {
+    const absoluteRuntimePath = path.join(
+      this.outputDirectory,
+      this.getAssets().runtime.js.replace(
+        new RegExp(`^${this.siteBasePath}`),
+        ''
+      )
+    );
+    return fs.readFileSync(absoluteRuntimePath, 'utf8');
+  }
+
   getHtmlSourceFn() {
     return dynamicRequire({
       absPath: this.htmlSource,

--- a/lib/default-underreact.config.js
+++ b/lib/default-underreact.config.js
@@ -1,5 +1,6 @@
 'use strict';
 const path = require('path');
+const fs = require('fs');
 
 module.exports = (cliOpts = {}) => {
   const rootDirectory = path.dirname(cliOpts.configPath);
@@ -30,7 +31,9 @@ module.exports = (cliOpts = {}) => {
     outputDirectory: path.join(rootDirectory, '_underreact-site'),
     publicDirectory: path.join(rootDirectory, 'public'),
     jsEntry: path.join(rootDirectory, 'src/entry.js'),
-    htmlSource: path.join(underreactRoot, 'lib', 'default-html.js'),
+    htmlSource: fs.existsSync(path.join(rootDirectory, 'src', 'html.js'))
+      ? path.join(rootDirectory, 'src', 'html.js')
+      : path.join(underreactRoot, 'lib', 'default-html.js'),
 
     // internal
     production: cliOpts.mode === 'production',

--- a/lib/html-compiler.js
+++ b/lib/html-compiler.js
@@ -63,14 +63,8 @@ function renderHtml(urc, cssFilename) {
   );
 }
 
-function uglifyRuntime(urc, assets) {
-  const absoluteRuntimePath = path.join(
-    urc.outputDirectory,
-    assets.runtime.js.replace(new RegExp(`^${urc.siteBasePath}`), '')
-  );
-  // TOFIX: remove the fs dependency
-  // somehow maybe have a promise which resolve into runtime value
-  const runtime = fs.readFileSync(absoluteRuntimePath, 'utf8');
+function uglifyRuntime(urc) {
+  const runtime = urc.getRuntimeJs();
   const uglifyResult = UglifyJs.minify(runtime);
   if (uglifyResult.error) throw uglifyResult.error;
   return uglifyResult.code;


### PR DESCRIPTION
This fixes a bug when running without setting the `urc.htmlSource` option but not loading the `src/html.js`.

@davidtheclark for review, please. 