### PR TITLE
Unify assets and html write

### DIFF
--- a/__tests__/__snapshots__/no-config.test.js.snap
+++ b/__tests__/__snapshots__/no-config.test.js.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`No Config Test builds the correct output with development mode 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "extension": ".html",
+      "name": "index.html",
+      "path": "<TEMP_DIR>/_underreact-site/index.html",
+      "size": 2256,
+      "type": "file",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "extension": ".js",
+          "name": "main.chunk.js",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/main.chunk.js",
+          "size": 4392,
+          "type": "file",
+        },
+        Object {
+          "extension": ".map",
+          "name": "main.chunk.js.map",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/main.chunk.js.map",
+          "size": 685,
+          "type": "file",
+        },
+        Object {
+          "extension": ".js",
+          "name": "polyfill.chunk.js",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/polyfill.chunk.js",
+          "size": 97853,
+          "type": "file",
+        },
+        Object {
+          "extension": ".map",
+          "name": "polyfill.chunk.js.map",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/polyfill.chunk.js.map",
+          "size": 67028,
+          "type": "file",
+        },
+        Object {
+          "extension": ".js",
+          "name": "runtime.js",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/runtime.js",
+          "size": 6241,
+          "type": "file",
+        },
+        Object {
+          "extension": ".map",
+          "name": "runtime.js.map",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/runtime.js.map",
+          "size": 6135,
+          "type": "file",
+        },
+        Object {
+          "extension": ".js",
+          "name": "vendor.chunk.js",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/vendor.chunk.js",
+          "size": 1353,
+          "type": "file",
+        },
+        Object {
+          "extension": ".map",
+          "name": "vendor.chunk.js.map",
+          "path": "<TEMP_DIR>/_underreact-site/underreact-assets/vendor.chunk.js.map",
+          "size": 287,
+          "type": "file",
+        },
+      ],
+      "name": "underreact-assets",
+      "path": "<TEMP_DIR>/_underreact-site/underreact-assets",
+      "size": 183974,
+      "type": "directory",
+    },
+  ],
+  "name": "_underreact-site",
+  "path": "<TEMP_DIR>/_underreact-site",
+  "size": 186230,
+  "type": "directory",
+}
+`;
+
 exports[`No Config Test builds the correct output without any configuration 1`] = `
 Object {
   "children": Array [

--- a/__tests__/no-config.test.js
+++ b/__tests__/no-config.test.js
@@ -43,6 +43,19 @@ describe('No Config Test', () => {
     expect(result.status).toBe(0);
   });
 
+  test('builds the correct output with development mode', () => {
+    const result = commandBuild(['--mode=development'], { cwd: dirPath });
+
+    const tree = removePath({
+      object: dirTree(path.join(dirPath, '_underreact-site')),
+      path: dirPath,
+      replaceWith: '<TEMP_DIR>'
+    });
+
+    expect(tree).toMatchSnapshot();
+    expect(result.status).toBe(0);
+  });
+
   test('exits with statusCode 1 when config is not found', () => {
     const result = commandBuild(
       [`--config=${path.join(dirPath, 'not-exists.config.js')}`],

--- a/commands/build.js
+++ b/commands/build.js
@@ -8,7 +8,7 @@ const Assets = require('../lib/assets');
 const logger = require('../lib/logger');
 const autoCopy = require('../lib/utils/auto-copy');
 const { WEBPACK_ASSETS_BASENAME } = require('../lib/constants');
-const { writeHtml } = require('../lib/html-compiler');
+const { htmlCompiler } = require('../lib/html-compiler');
 const { writeCss } = require('../lib/css-compiler');
 const {
   createWebpackConfig,
@@ -37,12 +37,11 @@ function build(urc) {
 
         return Promise.all([css, webpack, copy]);
       })
-
       .then(([cssOutput]) =>
-        writeHtml(urc)(
+        htmlCompiler(urc)(
           new Assets({
             urc,
-            cssOutput: cssOutput,
+            cssOutput,
             webpackAssets: path.join(
               urc.outputDirectory,
               WEBPACK_ASSETS_BASENAME

--- a/commands/build.js
+++ b/commands/build.js
@@ -4,6 +4,7 @@ const path = require('path');
 const del = require('del');
 const chalk = require('chalk');
 
+const Assets = require('../lib/assets');
 const logger = require('../lib/logger');
 const autoCopy = require('../lib/utils/auto-copy');
 const { WEBPACK_ASSETS_BASENAME } = require('../lib/constants');
@@ -16,25 +17,38 @@ const {
 } = require('../lib/webpack-helpers');
 
 function build(urc) {
-  logger.log(`Building your site in ${urc.mode} mode ...`);
-
+  logger.log(`Building your site in ${urc.mode} mode...`);
   const webpackConfig = createWebpackConfig(urc);
   // force is needed to get test fixtures passing
   return (
     del(urc.outputDirectory, { force: true })
-      .then(() => webpackPromise(webpackConfig))
-      .then(stats => {
-        if (urc.stats) {
-          return writeWebpackStats(urc.stats, stats);
-        }
-      })
-      .then(() => writeCss(urc))
-      .then(cssFilename => writeHtml(urc, cssFilename))
-      .then(() =>
-        autoCopy.copy({
+      .then(() => {
+        const webpack = webpackPromise(webpackConfig).then(stats => {
+          if (urc.stats) {
+            logger.log('Writing Webpack statistics ..');
+            return writeWebpackStats(urc.stats, stats);
+          }
+        });
+        const css = writeCss(urc).compilation;
+        const copy = autoCopy.copy({
           sourceDir: urc.publicDirectory,
           destDir: urc.outputDirectory
-        })
+        });
+
+        return Promise.all([css, webpack, copy]);
+      })
+
+      .then(([cssOutput]) =>
+        writeHtml(urc)(
+          new Assets({
+            urc,
+            cssOutput: cssOutput,
+            webpackAssets: path.join(
+              urc.outputDirectory,
+              WEBPACK_ASSETS_BASENAME
+            )
+          })
+        )
       )
       // Clean up files you won't need to deploy.
       .then(() =>

--- a/lib/__tests__/__snapshots__/html-compiler.test.js.snap
+++ b/lib/__tests__/__snapshots__/html-compiler.test.js.snap
@@ -1,6 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`jsBundles 1`] = `
+exports[`htmlCompiler polyfillScript renders correct html 1`] = `
+"<script>
+      var modernBrowser = (
+        true
+      );
+      if ( !modernBrowser ) {
+        var scriptElement = document.createElement('script');
+        scriptElement.async = false;
+        scriptElement.src = '/fakepath/polyfill-123.js';
+        document.head.appendChild(scriptElement);
+      }
+    </script>"
+`;
+
+exports[`htmlCompiler renderCssLinks renders correct html 1`] = `
+"<link rel=\\"stylesheet\\" href=\\"/fakepath/style-1.css\\">
+<link rel=\\"stylesheet\\" href=\\"/fakepath/style-2.css\\">"
+`;
+
+exports[`htmlCompiler renderJsBundles renders correct html 1`] = `
+"<script>uglified</script>
+<script src=\\"/fakepath/main-123.js\\"></script>
+<script src=\\"/fakepath/vendor-123.js\\"></script>"
+`;
+
+exports[`jsBundles outputs correct script tags 1`] = `
 "<script>uglified</script>
 <script src=\\"/fakepath/main-123.js\\"></script>
 <script src=\\"/fakepath/vendor-123.js\\"></script>"
@@ -18,29 +43,4 @@ exports[`polyfill works correctly when polyfill is switched on 1`] = `
         document.head.appendChild(scriptElement);
       }
     </script>"
-`;
-
-exports[`writeHtml calls polyfillScript correctly 1`] = `
-"<script>
-      var modernBrowser = (
-        true
-      );
-      if ( !modernBrowser ) {
-        var scriptElement = document.createElement('script');
-        scriptElement.async = false;
-        scriptElement.src = '/fakepath/polyfill-123.js';
-        document.head.appendChild(scriptElement);
-      }
-    </script>"
-`;
-
-exports[`writeHtml calls renderCssLinks correctly 1`] = `
-"<link rel=\\"stylesheet\\" href=\\"/fakepath/style-1.css\\">
-<link rel=\\"stylesheet\\" href=\\"/fakepath/style-2.css\\">"
-`;
-
-exports[`writeHtml calls renderJsBundles correctly 1`] = `
-"<script>uglified</script>
-<script src=\\"/fakepath/main-123.js\\"></script>
-<script src=\\"/fakepath/vendor-123.js\\"></script>"
 `;

--- a/lib/__tests__/__snapshots__/html-compiler.test.js.snap
+++ b/lib/__tests__/__snapshots__/html-compiler.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jsBundles 1`] = `
+"<script>uglified</script>
+<script src=\\"/fakepath/main-123.js\\"></script>
+<script src=\\"/fakepath/vendor-123.js\\"></script>"
+`;
+
+exports[`polyfill works correctly when polyfill is switched on 1`] = `
+"<script>
+      var modernBrowser = (
+        true
+      );
+      if ( !modernBrowser ) {
+        var scriptElement = document.createElement('script');
+        scriptElement.async = false;
+        scriptElement.src = '/fakepath/polyfill-123.js';
+        document.head.appendChild(scriptElement);
+      }
+    </script>"
+`;
+
+exports[`writeHtml calls polyfillScript correctly 1`] = `
+"<script>
+      var modernBrowser = (
+        true
+      );
+      if ( !modernBrowser ) {
+        var scriptElement = document.createElement('script');
+        scriptElement.async = false;
+        scriptElement.src = '/fakepath/polyfill-123.js';
+        document.head.appendChild(scriptElement);
+      }
+    </script>"
+`;
+
+exports[`writeHtml calls renderCssLinks correctly 1`] = `
+"<link rel=\\"stylesheet\\" href=\\"/fakepath/style-1.css\\">
+<link rel=\\"stylesheet\\" href=\\"/fakepath/style-2.css\\">"
+`;
+
+exports[`writeHtml calls renderJsBundles correctly 1`] = `
+"<script>uglified</script>
+<script src=\\"/fakepath/main-123.js\\"></script>
+<script src=\\"/fakepath/vendor-123.js\\"></script>"
+`;

--- a/lib/__tests__/assets.test.js
+++ b/lib/__tests__/assets.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const dynamicRequireMock = jest.fn();
+jest.mock('../utils/dynamic-require', () => {
+  return dynamicRequireMock;
+});
+
+const Assets = require('../assets');
+
+test('Loads webpack assets correctly', () => {
+  const webpackAssets = {};
+  dynamicRequireMock.mockReturnValueOnce(webpackAssets);
+  const assets = new Assets({
+    urc: {},
+    cssOutput: 'fake-css/output.css',
+    webpackAssets: 'fake-webpack-assets/file.json'
+  });
+
+  expect(assets.webpack).toBe(webpackAssets);
+  expect(dynamicRequireMock).toBeCalledWith({
+    absolutePath: 'fake-webpack-assets/file.json',
+    deleteCache: true
+  });
+});
+
+test('Returns main stylesheet path correctly', () => {
+  const assets = new Assets({
+    urc: {
+      outputDirectory: '/my/fake/output/',
+      siteBasePath: 'bar'
+    },
+    cssOutput: '/my/fake/output/style.css'
+  });
+
+  expect(assets.mainStylesheet).toBe('bar/style.css');
+});
+
+test('Returns all css path correctly', () => {
+  const webpackAssets = {
+    main: {
+      css: ['bar/foo-1.css', undefined, 'bar/foo-2.css']
+    }
+  };
+  dynamicRequireMock.mockReturnValueOnce(webpackAssets);
+  const assets = new Assets({
+    urc: {
+      outputDirectory: '/my/fake/output/',
+      siteBasePath: 'bar'
+    },
+    cssOutput: '/my/fake/output/deep/style.css',
+    webpackAssets: 'fake-webpack-assets/file.json'
+  });
+
+  expect(assets.css).toEqual([
+    'bar/deep/style.css',
+    'bar/foo-1.css',
+    'bar/foo-2.css'
+  ]);
+});
+
+describe('absolutePathToRelativeUrl', () => {
+  test('handles when there is no absolute path', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/output/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+    expect(assets.absolutePathToRelativeUrl()).toBeUndefined();
+  });
+  test('handles an array', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+    expect(
+      assets.absolutePathToRelativeUrl([
+        '/my/fake/path/1.js',
+        '/my/fake/2.js',
+        '/my/fake/path/very/long/3.js'
+      ])
+    ).toMatchInlineSnapshot(`
+Array [
+  "bar/path/1.js",
+  "bar/2.js",
+  "bar/path/very/long/3.js",
+]
+`);
+  });
+
+  test('handles a single path', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/output/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+
+    expect(assets.absolutePathToRelativeUrl('/my/fake/output/style.css')).toBe(
+      'bar/style.css'
+    );
+  });
+});
+
+describe('relativeUrlToAbsolutePath', () => {
+  test('handles when there is no relative path', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/output/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+    expect(assets.relativeUrlToAbsolutePath()).toBeUndefined();
+  });
+  test('handles an array', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+    expect(
+      assets.relativeUrlToAbsolutePath([
+        'bar/path/1.js',
+        'bar/2.js',
+        'bar/path/very/long/3.js'
+      ])
+    ).toMatchInlineSnapshot(`
+Array [
+  "/my/fake/path/1.js",
+  "/my/fake/2.js",
+  "/my/fake/path/very/long/3.js",
+]
+`);
+  });
+
+  test('handles a single path', () => {
+    const assets = new Assets({
+      urc: {
+        outputDirectory: '/my/fake/output/',
+        siteBasePath: 'bar'
+      },
+      cssOutput: '/my/fake/output/style.css'
+    });
+
+    expect(assets.relativeUrlToAbsolutePath('bar/style.css')).toBe(
+      '/my/fake/output/style.css'
+    );
+  });
+});

--- a/lib/__tests__/css-compiler.test.js
+++ b/lib/__tests__/css-compiler.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const concatToFileMock = jest.fn();
+const autoprefixerMock = jest.fn();
+
+jest.mock('../../packages/postcss-concatenator', () => ({
+  concatToFile: concatToFileMock
+}));
+
+jest.mock('autoprefixer', () => {
+  return autoprefixerMock;
+});
+
+const { writeCss } = require('../css-compiler');
+
+test('output depends on compilation in production', () => {
+  const urc = {
+    stylesheets: ['/foo/mystylesheet'],
+    production: true,
+    publicAssetsPath: 'fake-assets',
+    outputDirectory: 'fake-output',
+    postcssPlugins: ['fake-plugin'],
+    getBrowserslist: () => 'fake-browserslist'
+  };
+  concatToFileMock.mockResolvedValueOnce('mock-value');
+  const { output, compilation } = writeCss(urc);
+
+  expect(output).toBe(compilation);
+  return expect(output).resolves.toEqual('mock-value');
+});
+
+test('output is resolved independent of compilation in development', () => {
+  const urc = {
+    stylesheets: ['/foo/mystylesheet'],
+    production: false,
+    publicAssetsPath: 'fake-assets',
+    outputDirectory: 'fake-output',
+    postcssPlugins: ['fake-plugin'],
+    getBrowserslist: () => 'fake-browserslist'
+  };
+
+  concatToFileMock.mockResolvedValueOnce('mock-value');
+
+  const { output, compilation } = writeCss(urc);
+
+  expect(output).not.toBe(compilation);
+  return expect(output).resolves.toEqual(
+    'fake-output/fake-assets/underreact-styles.css'
+  );
+});

--- a/lib/__tests__/css-compiler.test.js
+++ b/lib/__tests__/css-compiler.test.js
@@ -13,23 +13,7 @@ jest.mock('autoprefixer', () => {
 
 const { writeCss } = require('../css-compiler');
 
-test('output depends on compilation in production', () => {
-  const urc = {
-    stylesheets: ['/foo/mystylesheet'],
-    production: true,
-    publicAssetsPath: 'fake-assets',
-    outputDirectory: 'fake-output',
-    postcssPlugins: ['fake-plugin'],
-    getBrowserslist: () => 'fake-browserslist'
-  };
-  concatToFileMock.mockResolvedValueOnce('mock-value');
-  const { output, compilation } = writeCss(urc);
-
-  expect(output).toBe(compilation);
-  return expect(output).resolves.toEqual('mock-value');
-});
-
-test('output is resolved independent of compilation in development', () => {
+test('css compiler works correctly', () => {
   const urc = {
     stylesheets: ['/foo/mystylesheet'],
     production: false,
@@ -39,12 +23,12 @@ test('output is resolved independent of compilation in development', () => {
     getBrowserslist: () => 'fake-browserslist'
   };
 
-  concatToFileMock.mockResolvedValueOnce('mock-value');
+  concatToFileMock.mockResolvedValueOnce(
+    'fake-output/fake-assets/underreact-styles.css'
+  );
 
-  const { output, compilation } = writeCss(urc);
-
-  expect(output).not.toBe(compilation);
-  return expect(output).resolves.toEqual(
+  const compilation = writeCss(urc);
+  return expect(compilation).resolves.toEqual(
     'fake-output/fake-assets/underreact-styles.css'
   );
 });

--- a/lib/__tests__/html-compiler.test.js
+++ b/lib/__tests__/html-compiler.test.js
@@ -1,0 +1,114 @@
+'use strict';
+const tempy = require('tempy');
+const path = require('path');
+const fs = require('fs');
+
+jest.mock('uglify-js', () => ({
+  minify: jest.fn()
+}));
+
+const minifyMock = require('uglify-js').minify;
+
+const { writeHtml, jsBundles, polyfill } = require('../html-compiler');
+
+test('jsBundles', () => {
+  const tempDir = tempy.directory();
+  fs.writeFileSync(path.join(tempDir, 'vendor-123.js'), 'VENDOR');
+
+  const assets = {
+    relativeUrlToAbsolutePath: () => path.join(tempDir, 'vendor-123.js'),
+    webpack: {
+      main: {
+        js: '/fakepath/main-123.js'
+      },
+      vendor: {
+        js: '/fakepath/vendor-123.js'
+      },
+      runtime: {
+        js: '/fakepath/runtime-123.js'
+      }
+    }
+  };
+  minifyMock.mockReturnValueOnce({ code: 'uglified' });
+  expect(jsBundles(assets)()).toMatchSnapshot();
+
+  expect(minifyMock).toBeCalledWith('VENDOR');
+});
+
+test('polyfill works correctly when polyfill is switched on', () => {
+  const urc = {
+    modernBrowserTest: 'true'
+  };
+  const assets = {
+    webpack: {
+      polyfill: {
+        js: '/fakepath/polyfill-123.js'
+      }
+    }
+  };
+  expect(polyfill(urc, assets)()).toMatchSnapshot();
+});
+test('polyfill works correctly when polyfill is switched off', () => {
+  const urc = {
+    modernBrowserTest: 'true'
+  };
+  const assets = {
+    webpack: {}
+  };
+  expect(polyfill(urc, assets)()).toBe('');
+});
+
+describe('writeHtml', () => {
+  let urc;
+  let tempDir;
+  let assets;
+  beforeEach(() => {
+    tempDir = tempy.directory();
+    fs.writeFileSync(path.join(tempDir, 'vendor-123.js'), 'VENDOR');
+    assets = {
+      relativeUrlToAbsolutePath: () => path.join(tempDir, 'vendor-123.js'),
+      webpack: {
+        main: {
+          js: '/fakepath/main-123.js'
+        },
+        vendor: {
+          js: '/fakepath/vendor-123.js'
+        },
+        polyfill: {
+          js: '/fakepath/polyfill-123.js'
+        },
+        runtime: {
+          js: '/fakepath/runtime-123.js'
+        }
+      },
+      css: ['/fakepath/style-1.css', '/fakepath/style-2.css']
+    };
+    urc = {
+      modernBrowserTest: 'true',
+      outputDirectory: tempDir,
+      htmlSource: jest.fn()
+    };
+    minifyMock.mockReturnValueOnce({ code: 'uglified' });
+  });
+  test('calls renderCssLinks correctly', () => {
+    return writeHtml(urc)(assets).then(() => {
+      expect(urc.htmlSource).toHaveBeenCalledTimes(1);
+      const { renderCssLinks } = urc.htmlSource.mock.calls[0][0];
+      expect(renderCssLinks()).toMatchSnapshot();
+    });
+  });
+  test('calls renderJsBundles correctly', () => {
+    return writeHtml(urc)(assets).then(() => {
+      expect(urc.htmlSource).toHaveBeenCalledTimes(1);
+      const { renderJsBundles } = urc.htmlSource.mock.calls[0][0];
+      expect(renderJsBundles()).toMatchSnapshot();
+    });
+  });
+  test('calls polyfillScript correctly', () => {
+    return writeHtml(urc)(assets).then(() => {
+      expect(urc.htmlSource).toHaveBeenCalledTimes(1);
+      const { polyfillScript } = urc.htmlSource.mock.calls[0][0];
+      expect(polyfillScript()).toMatchSnapshot();
+    });
+  });
+});

--- a/lib/__tests__/html-compiler.test.js
+++ b/lib/__tests__/html-compiler.test.js
@@ -9,9 +9,9 @@ jest.mock('uglify-js', () => ({
 
 const minifyMock = require('uglify-js').minify;
 
-const { writeHtml, jsBundles, polyfill } = require('../html-compiler');
+const { htmlCompiler, jsBundles, polyfill } = require('../html-compiler');
 
-test('jsBundles', () => {
+test('jsBundles outputs correct script tags', () => {
   const tempDir = tempy.directory();
   fs.writeFileSync(path.join(tempDir, 'vendor-123.js'), 'VENDOR');
 
@@ -58,7 +58,7 @@ test('polyfill works correctly when polyfill is switched off', () => {
   expect(polyfill(urc, assets)()).toBe('');
 });
 
-describe('writeHtml', () => {
+describe('htmlCompiler', () => {
   let urc;
   let tempDir;
   let assets;
@@ -90,22 +90,22 @@ describe('writeHtml', () => {
     };
     minifyMock.mockReturnValueOnce({ code: 'uglified' });
   });
-  test('calls renderCssLinks correctly', () => {
-    return writeHtml(urc)(assets).then(() => {
+  test('renderCssLinks renders correct html', () => {
+    return htmlCompiler(urc)(assets).then(() => {
       expect(urc.htmlSource).toHaveBeenCalledTimes(1);
       const { renderCssLinks } = urc.htmlSource.mock.calls[0][0];
       expect(renderCssLinks()).toMatchSnapshot();
     });
   });
-  test('calls renderJsBundles correctly', () => {
-    return writeHtml(urc)(assets).then(() => {
+  test('renderJsBundles renders correct html', () => {
+    return htmlCompiler(urc)(assets).then(() => {
       expect(urc.htmlSource).toHaveBeenCalledTimes(1);
       const { renderJsBundles } = urc.htmlSource.mock.calls[0][0];
       expect(renderJsBundles()).toMatchSnapshot();
     });
   });
-  test('calls polyfillScript correctly', () => {
-    return writeHtml(urc)(assets).then(() => {
+  test('polyfillScript renders correct html', () => {
+    return htmlCompiler(urc)(assets).then(() => {
       expect(urc.htmlSource).toHaveBeenCalledTimes(1);
       const { polyfillScript } = urc.htmlSource.mock.calls[0][0];
       expect(polyfillScript()).toMatchSnapshot();

--- a/lib/assets.js
+++ b/lib/assets.js
@@ -1,0 +1,66 @@
+'use strict';
+const urlJoin = require('url-join');
+const path = require('path');
+
+const dynamicRequire = require('./utils/dynamic-require');
+
+// Contains all assets that could be needed by index.html
+// Note: all asset paths are relative to host
+class Assets {
+  constructor({ urc, cssOutput, webpackAssets }) {
+    this.urc = urc;
+    this._cssOutput = cssOutput;
+    this._webpackAssets = webpackAssets;
+  }
+
+  get webpack() {
+    return dynamicRequire({
+      absolutePath: this._webpackAssets,
+      deleteCache: true
+    });
+  }
+
+  get css() {
+    const webpackAssets = this.webpack;
+    const mainStylesheet = this.mainStylesheet;
+    return [mainStylesheet].concat(webpackAssets.main.css).filter(Boolean);
+  }
+
+  get mainStylesheet() {
+    const absolutePath = this._cssOutput;
+
+    return this.absolutePathToRelativeUrl(absolutePath);
+  }
+
+  // converts an absolute filesystem path to a browser friendly relative url
+  absolutePathToRelativeUrl(absolutePath) {
+    if (!absolutePath) {
+      return;
+    }
+
+    if (Array.isArray(absolutePath)) {
+      return absolutePath.map(path => this.absolutePathToRelativeUrl(path));
+    }
+
+    const relativePath = path.relative(this.urc.outputDirectory, absolutePath);
+    return urlJoin(this.urc.siteBasePath, ...relativePath.split(path.sep));
+  }
+
+  // converts an relative url  to an absolute filesystem path
+  relativeUrlToAbsolutePath(relativeUrl) {
+    if (!relativeUrl) {
+      return;
+    }
+
+    if (Array.isArray(relativeUrl)) {
+      return relativeUrl.map(url => this.relativeUrlToAbsolutePath(url));
+    }
+
+    return path.join(
+      this.urc.outputDirectory,
+      relativeUrl.replace(new RegExp(`^${this.urc.siteBasePath}`), '')
+    );
+  }
+}
+
+module.exports = Assets;

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -9,11 +9,7 @@ module.exports = {
   writeCss
 };
 
-/**
- * @returns {Object} result
- *    {Promise<string>} result.output - A promise which resolves to path of the output css file.
- *    {Promise<string>} result.compilation - A promise which resolves when css is written to disk.
- */
+// Returns a promise which resolves to the output path of css
 function writeCss(urc) {
   const mainStylesheet =
     urc.stylesheets.length > 0
@@ -24,7 +20,7 @@ function writeCss(urc) {
     return { output: Promise.resolve(), compilation: Promise.resolve() };
   }
 
-  const compilation = concatToFile({
+  return concatToFile({
     plugins: [
       autoprefixer({ browsers: urc.getBrowserslist() }),
       ...urc.postcssPlugins
@@ -34,20 +30,4 @@ function writeCss(urc) {
     hash: urc.production,
     sourceMap: urc.production ? 'file' : 'inline'
   });
-
-  // in case of production, css is hashed and
-  // this hashed path can only be known once compilation is complete
-  if (urc.production) {
-    return {
-      output: compilation, // compilation promise resolves to the hashed output path of css
-      compilation
-    };
-  }
-
-  // In case of development, we already know the final path of the output
-  // and don't need to block any process.
-  return {
-    output: Promise.resolve(mainStylesheet),
-    compilation
-  };
 }

--- a/lib/css-compiler.js
+++ b/lib/css-compiler.js
@@ -1,7 +1,6 @@
 'use strict';
-
-const path = require('path');
 const autoprefixer = require('autoprefixer');
+const path = require('path');
 
 const { concatToFile } = require('../packages/postcss-concatenator');
 const { CSS_BASENAME } = require('./constants');
@@ -10,24 +9,45 @@ module.exports = {
   writeCss
 };
 
+/**
+ * @returns {Object} result
+ *    {Promise<string>} result.output - A promise which resolves to path of the output css file.
+ *    {Promise<string>} result.compilation - A promise which resolves when css is written to disk.
+ */
 function writeCss(urc) {
-  if (urc.stylesheets.length === 0) {
-    return Promise.resolve();
+  const mainStylesheet =
+    urc.stylesheets.length > 0
+      ? path.join(urc.outputDirectory, urc.publicAssetsPath, CSS_BASENAME)
+      : undefined;
+
+  if (!mainStylesheet) {
+    return { output: Promise.resolve(), compilation: Promise.resolve() };
   }
 
-  const output = path.join(
-    urc.outputDirectory,
-    urc.publicAssetsPath,
-    CSS_BASENAME
-  );
-  return concatToFile({
+  const compilation = concatToFile({
     plugins: [
       autoprefixer({ browsers: urc.getBrowserslist() }),
       ...urc.postcssPlugins
     ],
     stylesheets: urc.stylesheets,
-    output,
+    output: mainStylesheet,
     hash: urc.production,
     sourceMap: urc.production ? 'file' : 'inline'
-  }).then(() => output);
+  });
+
+  // in case of production, css is hashed and
+  // this hashed path can only be known once compilation is complete
+  if (urc.production) {
+    return {
+      output: compilation, // compilation promise resolves to the hashed output path of css
+      compilation
+    };
+  }
+
+  // In case of development, we already know the final path of the output
+  // and don't need to block any process.
+  return {
+    output: Promise.resolve(mainStylesheet),
+    compilation
+  };
 }

--- a/lib/html-compiler.js
+++ b/lib/html-compiler.js
@@ -3,55 +3,62 @@
 const fs = require('fs');
 const path = require('path');
 const UglifyJs = require('uglify-js');
-const urlJoin = require('url-join');
 const promisify = require('util.promisify');
 
-const { CSS_BASENAME } = require('./constants');
+const writeFile = promisify(fs.writeFile);
 
-module.exports = { renderHtml, writeHtml };
+module.exports = { writeHtml, polyfill, jsBundles, cssLinks };
 
-function renderHtml(urc, cssFilename) {
-  const assets = urc.getAssets();
+function writeHtml(urc) {
+  let prevHtml;
+  return assets =>
+    Promise.resolve(
+      urc.htmlSource({
+        polyfillScript: polyfill(urc, assets),
+        renderJsBundles: jsBundles(assets),
+        renderCssLinks: cssLinks(assets)
+      })
+    ).then(html => {
+      if (prevHtml && html === prevHtml) {
+        return;
+      }
+      return writeFile(path.join(urc.outputDirectory, 'index.html'), html).then(
+        () => {
+          prevHtml = html;
+        }
+      );
+    });
+}
+
+function jsBundles(assets) {
   // Inline the runtime JS because it's super small.
-  const uglifiedRuntime = uglifyRuntime(urc, assets);
+  const uglifiedRuntime = uglifyRuntime(assets);
+  return () => {
+    const bundledScripts = [
+      `<script>${uglifiedRuntime}</script>`,
+      `<script src="${assets.webpack.main.js}"></script>`
+    ];
+    // handles edge case when user doesn't import any module
+    if (assets.webpack.vendor && assets.webpack.vendor.js) {
+      bundledScripts.push(
+        `<script src="${assets.webpack.vendor.js}"></script>`
+      );
+    }
 
-  const bundledScripts = [
-    `<script>${uglifiedRuntime}</script>`,
-    `<script src="${assets.main.js}"></script>`
-  ];
-
-  // handles edge case when user doesn't import any module
-  if (assets.vendor && assets.vendor.js) {
-    bundledScripts.push(`<script src="${assets.vendor.js}"></script>`);
-  }
-
-  const renderJsBundles = () => {
     return bundledScripts.join('\n');
   };
+}
 
-  const cssAssets = [].concat(assets.main.css).filter(x => !!x);
+function cssLinks(assets) {
+  return () =>
+    assets.css
+      .map(assetPath => `<link rel="stylesheet" href="${assetPath}">`)
+      .join('\n');
+}
 
-  if (cssFilename) {
-    cssAssets.push(
-      urlJoin(
-        ...path.relative(urc.outputDirectory, cssFilename).split(path.sep)
-      )
-    );
-  } else if (urc.stylesheets.length !== 0 && !urc.production) {
-    cssAssets.push(
-      urlJoin(urc.siteBasePath, urc.publicAssetsPath, CSS_BASENAME)
-    );
-  }
-  const cssLinks = cssAssets.map(assetPath => {
-    return `<link rel="stylesheet" href="${assetPath}">`;
-  });
-
-  const renderCssLinks = () => {
-    return cssLinks.join('\n');
-  };
-
-  const polyfillScript = () =>
-    urc.polyfill
+function polyfill(urc, assets) {
+  return () =>
+    assets.webpack.polyfill
       ? `<script>
       var modernBrowser = (
         ${urc.modernBrowserTest}
@@ -59,30 +66,18 @@ function renderHtml(urc, cssFilename) {
       if ( !modernBrowser ) {
         var scriptElement = document.createElement('script');
         scriptElement.async = false;
-        scriptElement.src = '${assets.polyfill.js}';
+        scriptElement.src = '${assets.webpack.polyfill.js}';
         document.head.appendChild(scriptElement);
       }
     </script>`
       : '';
-
-  return Promise.resolve(
-    urc.htmlSource({
-      polyfillScript,
-      renderJsBundles,
-      renderCssLinks
-    })
-  );
 }
 
-function uglifyRuntime(urc) {
-  const runtime = urc.getRuntimeJs();
-  const uglifyResult = UglifyJs.minify(runtime);
+function uglifyRuntime(assets) {
+  const path = assets.relativeUrlToAbsolutePath(assets.webpack.runtime.js);
+  const uglifyResult = UglifyJs.minify(fs.readFileSync(path, 'utf8'));
+
   if (uglifyResult.error) throw uglifyResult.error;
-  return uglifyResult.code;
-}
 
-function writeHtml(urc, cssFilename) {
-  return renderHtml(urc, cssFilename).then(html =>
-    promisify(fs.writeFile)(path.join(urc.outputDirectory, 'index.html'), html)
-  );
+  return uglifyResult.code;
 }

--- a/lib/html-compiler.js
+++ b/lib/html-compiler.js
@@ -7,10 +7,11 @@ const promisify = require('util.promisify');
 
 const writeFile = promisify(fs.writeFile);
 
-module.exports = { writeHtml, polyfill, jsBundles, cssLinks };
+module.exports = { htmlCompiler, polyfill, jsBundles, cssLinks };
 
-function writeHtml(urc) {
+function htmlCompiler(urc) {
   let prevHtml;
+
   return assets =>
     Promise.resolve(
       urc.htmlSource({
@@ -38,7 +39,8 @@ function jsBundles(assets) {
       `<script>${uglifiedRuntime}</script>`,
       `<script src="${assets.webpack.main.js}"></script>`
     ];
-    // handles edge case when user doesn't import any module
+    // Handles the edge edge case when there are no vendor modules.
+    // This could happen if the user doesn't use any node modules.
     if (assets.webpack.vendor && assets.webpack.vendor.js) {
       bundledScripts.push(
         `<script src="${assets.webpack.vendor.js}"></script>`
@@ -57,9 +59,11 @@ function cssLinks(assets) {
 }
 
 function polyfill(urc, assets) {
-  return () =>
-    assets.webpack.polyfill
-      ? `<script>
+  return () => {
+    if (!assets.webpack.polyfill) {
+      return '';
+    }
+    return `<script>
       var modernBrowser = (
         ${urc.modernBrowserTest}
       );
@@ -69,8 +73,8 @@ function polyfill(urc, assets) {
         scriptElement.src = '${assets.webpack.polyfill.js}';
         document.head.appendChild(scriptElement);
       }
-    </script>`
-      : '';
+    </script>`;
+  };
 }
 
 function uglifyRuntime(assets) {

--- a/lib/start-server.js
+++ b/lib/start-server.js
@@ -3,18 +3,23 @@
 const reloadingServer = require('./utils/reloading-server');
 const logger = require('./logger');
 
-function startServer(urc) {
-  const server = reloadingServer({
-    dir: urc.outputDirectory,
-    port: urc.port,
-    siteBasePath: urc.siteBasePath,
-    historyFallback: urc.devServerHistoryFallback
-  });
+const delay = t => new Promise(res => setTimeout(res, t));
 
-  server.on('info', logger.log);
-  server.on('error', logger.error);
-  return new Promise(resolve => {
-    server.on('ready', resolve);
+function startServer(urc) {
+  // Give a slight delay to let build tasks settle
+  return delay(400).then(() => {
+    const server = reloadingServer({
+      dir: urc.outputDirectory,
+      port: urc.port,
+      siteBasePath: urc.siteBasePath,
+      historyFallback: urc.devServerHistoryFallback
+    });
+
+    server.on('info', logger.log);
+    server.on('error', logger.error);
+    return new Promise(resolve => {
+      server.on('ready', resolve);
+    });
   });
 }
 


### PR DESCRIPTION
It adds the following things:
- A unified assets object, which handles the paths for any asset that can be needed by `index.html`
- Fixes the weird bugs when running `mode=production` with `start` command.
- Optimizes `css` and `copy` tasks, as they don't depend on `webpack`.
- Adds a bunch of tests to improve unit testing coverage.
- Improve the Html writing.

@davidtheclark for review, please.
Note: This each commit is individually reviewable. 