### PR TITLE
HOT 🔥

### DIFF
--- a/commands/start.js
+++ b/commands/start.js
@@ -55,7 +55,8 @@ function watchWebpack(urc, callback) {
       index: urc.siteBasePath
     },
     port: urc.port,
-    compress: urc.production
+    compress: urc.production,
+    hot: urc.hot
   });
 
   server.listen(urc.port, '127.0.0.1', () => {

--- a/examples/fancy/.babelrc
+++ b/examples/fancy/.babelrc
@@ -1,5 +1,4 @@
 {
-    "presets": [
-        "../../packages/babel-preset-mapbox"
-    ]
+  "presets": ["../../packages/babel-preset-mapbox"],
+  "plugins": ["react-hot-loader/babel"]
 }

--- a/examples/fancy/package.json
+++ b/examples/fancy/package.json
@@ -10,7 +10,8 @@
     "lodash": "^4.17.10",
     "p-finally": "^1.0.0",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react-dom": "^16.0.0",
+    "react-hot-loader": "^4.3.11"
   },
   "devDependencies": {
     "less": "^3.0.4",

--- a/examples/fancy/src/app.js
+++ b/examples/fancy/src/app.js
@@ -1,11 +1,21 @@
 import React from 'react';
 import _ from 'lodash';
 import pFinally from 'p-finally';
+import { hot } from 'react-hot-loader';
+
+import Child from './child';
 import './bg.css';
 import './styles.less';
 
-export default class App extends React.Component {
+class App extends React.Component {
+  state = {
+    counter: 0
+  };
   componentDidMount() {
+    setInterval(
+      () => this.setState(state => ({ counter: state.counter + 1 })),
+      1500
+    );
     pFinally(Promise.resolve(), () => {
       console.log('resolved!');
     });
@@ -16,36 +26,37 @@ export default class App extends React.Component {
   render() {
     return (
       <div>
+        <p>Here's a random number: {_.random(0, 100)}</p>
+        <p>Here's a the state counter: {this.state.counter}</p>
+        <Child />
         <p>
-          Here's a random number: {_.random(0, 100)}
+          Did the DefinePlugin work?{' '}
+          {typeof DEFINE_WORKED === 'undefined' ? 'No' : DEFINE_WORKED}
+        </p>
+        <p>Less-loading worked if this text is light blue.</p>
+        <p>
+          Value of the env variable passed through cli ENV_VAR:{' '}
+          {process.env.UNDERREACT_APP_ENV_VAR}
         </p>
         <p>
-          Did the DefinePlugin work? {typeof DEFINE_WORKED === 'undefined' ? 'No' : DEFINE_WORKED}
+          Value of the env variable from file UNDERREACT_APP_CLIENT_TOKEN:{' '}
+          {process.env.UNDERREACT_APP_CLIENT_TOKEN}
         </p>
         <p>
-          Less-loading worked if this text is light blue.
+          Does it leak SECRET_TOKEN:{' '}
+          {process.env.SECRET_TOKEN === undefined ? 'No' : 'Yes'}
         </p>
-        <p>
-          Value of the env variable passed through cli ENV_VAR: {process.env.UNDERREACT_APP_ENV_VAR}
-        </p>
-        <p>
-          Value of the env variable from file UNDERREACT_APP_CLIENT_TOKEN: {process.env.UNDERREACT_APP_CLIENT_TOKEN}
-        </p>
-        <p>
-        Does it leak SECRET_TOKEN: {process.env.SECRET_TOKEN === undefined? 'No': 'Yes'}
-        </p>
-        <p>
-          Background image snowflake:
-        </p>
-        <div className="snowflake" style={{ height: 300, width: 300 }}/>
-        <p>
-          Real image snowflake:
-        </p>
+        <p>Background image snowflake:</p>
+        <div className="snowflake" style={{ height: 300, width: 300 }} />
+        <p>Real image snowflake:</p>
         <img src="images/snowflake.jpg" />
         <p>
-          The library <code>p-finally</code> is not ES5, so this page should throw an error in older browsers like IE11.
+          The library <code>p-finally</code> is not ES5, so this page should
+          throw an error in older browsers like IE11.
         </p>
       </div>
     );
   }
 }
+
+export default hot(module)(App);

--- a/examples/fancy/src/bg.css
+++ b/examples/fancy/src/bg.css
@@ -1,8 +1,10 @@
 @font-face {
   font-family: 'Open Sans';
   font-weight: bold;
-  src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff2') format('woff2'),
-    url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff') format('woff');
+  src: url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff2')
+      format('woff2'),
+    url('https://api.mapbox.com/mapbox-assembly/fonts/opensans-regular.v1.woff')
+      format('woff');
 }
 
 body {

--- a/examples/fancy/src/child.js
+++ b/examples/fancy/src/child.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default class Child extends React.Component {
+  state = {
+    counter: 0
+  };
+  componentDidMount() {
+    setInterval(
+      () => this.setState(state => ({ counter: state.counter + 2 })),
+      1500
+    );
+  }
+  render() {
+    return (
+      <>
+        <div>Here is child counter: {this.state.counter}</div>
+      </>
+    );
+  }
+}

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
 const htmlSource = ({ renderCssLinks, renderJsBundles }) => {
@@ -25,6 +25,7 @@ const htmlSource = ({ renderCssLinks, renderJsBundles }) => {
 
 module.exports = ({ webpack }) => {
   return {
+    hot: true,
     polyfill: path.join(__dirname, 'polyfill.js'),
     siteBasePath: 'fancy',
     publicAssetsPath: 'cacheable-things',
@@ -33,11 +34,7 @@ module.exports = ({ webpack }) => {
     webpackLoaders: [
       {
         test: /\.less$/,
-        use: [
-          MiniCssExtractPlugin.loader,
-          'css-loader',
-          'less-loader',
-        ]
+        use: [MiniCssExtractPlugin.loader, 'css-loader', 'less-loader']
       }
     ],
     webpackPlugins: [
@@ -50,14 +47,8 @@ module.exports = ({ webpack }) => {
       return config;
     },
     browserslist: {
-      development: [
-        '> 1%',
-        'ie 10'
-      ],
-      development: [
-        'last 1 chrome version',
-        'last 1 firefox version'
-      ]
+      development: ['> 1%', 'ie 10'],
+      production: ['last 1 chrome version', 'last 1 firefox version']
     }
   };
 };


### PR DESCRIPTION
This turned out simpler than I thought...
This PR enables hot reloading of apps. 

I will be updating docs in the next round of PRs. Right now I am not thinking of including `react-hot-loader` in `babel-preset-mapbox`. If a user can wants to enable hot-reload, they can follow instructions which would include creating a `.babelrc` file similar to what we have in `fancy` example and install `react-hot-loader` to get started with hot-reload.

cc @davidtheclark 