### PR TITLE
`htmlSource` need not to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ You have 2 choices:
 - **Preferred:** Provide [`htmlSource`](#htmlsource) which is an HTML string or a Promise that resolves to an HTML string.
 - Provide no HTML-rendering function and let Underreact use the default HTML document. *You should only do this for prototyping and early development*: for production projects, you'll definitely want to define your own HTML at some point, if only for the `<title>`.
 
-If you use provide a promise, you can use any async I/O you need to put together the page. For example, you could read JS files and inject their code directly into `<script>` tags, or inject CSS into `<style>` tags. Or you could make an HTTP call to fetch dynamic data and inject it into the page with a `<script>` tag, so it's available to your React app.
+If you provide a promise, you can use any async I/O you need to put together the page. For example, you could read JS files and inject their code directly into `<script>` tags, or inject CSS into `<style>` tags. Or you could make an HTTP call to fetch dynamic data and inject it into the page with a `<script>` tag, so it's available to your React app.
 
-**Note: Underreact would automatically inject build outputs `script` and `link` tags to your HTML template.**
+**Note: Underreact would automatically inject output `script` and `link` tags to your HTML template.**
 
 In the example below, we are defining `htmlSource` in a separate file and requiring it in `underreact.config.js`:
 

--- a/README.md
+++ b/README.md
@@ -190,17 +190,14 @@ Underreact is intended for single-page apps, so you only need one HTML page. If 
 
 You have 2 choices:
 
-- **Preferred:** Provide a function for [`htmlSource`](#htmlsource) that returns an HTML string or a Promise that resolves with an HTML string.
+- **Preferred:** Provide [`htmlSource`](#htmlsource) which is an HTML string or a Promise that resolves to an HTML string.
 - Provide no HTML-rendering function and let Underreact use the default HTML document. *You should only do this for prototyping and early development*: for production projects, you'll definitely want to define your own HTML at some point, if only for the `<title>`.
 
-In your function, you can use JS template literals to interpolate expressions, and you can use any async I/O you need to put together the page. For example, you could read JS files and inject their code directly into `<script>` tags, or inject CSS into `<style>` tags. Or you could make an HTTP call to fetch dynamic data and inject it into the page with a `<script>` tag, so it's available to your React app.
+If you use provide a promise, you can use any async I/O you need to put together the page. For example, you could read JS files and inject their code directly into `<script>` tags, or inject CSS into `<style>` tags. Or you could make an HTTP call to fetch dynamic data and inject it into the page with a `<script>` tag, so it's available to your React app.
 
-The function exported by your JS module will be passed a context object with the following properties:
+**Note: Underreact would automatically inject build outputs `script` and `link` tags to your HTML template.**
 
-- `renderJsBundles`: **You must use this callback function to add JS to the page.** Typically you'll invoke it at the end of your `<body>`. It adds the `<script>` tags that pull in Webpack bundles.
-- `renderCssLinks`: **You must use this callback function to add CSS to the page,** unless your only sources of CSS are `<link>`s and `<style>`s that you write directly into your HTML.
-
-In the example below, we are defining our custom `htmlSource` function in a separate file and requiring it in `underreact.config.js`:
+In the example below, we are defining `htmlSource` in a separate file and requiring it in `underreact.config.js`:
 
 ```js
 // underreact.config.js
@@ -217,7 +214,7 @@ const fs = require('fs');
 const { promisify } = require('util');
 const minimizeJs = require('./minimize-js');
 
-module.exports = mode => async ({ renderJsBundles, renderCssLinks }) => {
+module.exports = async mode => {
     // read an external script, which we will inline
     let inlineJs = await promisify(fs.readFile)(
      './path/to/some-script.js'
@@ -234,14 +231,12 @@ module.exports = mode => async ({ renderJsBundles, renderCssLinks }) => {
         <meta charset="utf-8">
         <title>Words that rhyme with fish</title>
         <meta name="description" content="A website about words that rhyme with fish, like plish">
-        ${renderCssLinks()}
         <script>${inlineJs}</script>
       </head>
       <body>
         <div id="app">
           <!-- React app will be rendered into this div -->
         </div>
-        ${renderJsBundles()}
       </body>
       </html>
     `;
@@ -466,11 +461,9 @@ Set to `true` if you want to use HTML5 History for client-side routing (as oppos
 
 ### htmlSource
 
-Type: `Function`.  Default: `[Default HTML](https://github.com/mapbox/underreact/blob/next/lib/default-html.js)`.
+Type: `string`\|`Promise.  Default:`[Default HTML](https://github.com/mapbox/underreact/blob/next/lib/default-html.js)\`.
 
-The function to generate HTML template for your app. Read [`Defining your HTML`](#defining-your-html) for more details.
-
-**Tip**: It is recommended that you keep this function in a separate module, and then require it from your Underreact config module.
+The value to be used to generate HTML template for your app. Read [`Defining your HTML`](#defining-your-html) for more details.
 
 ### jsEntry
 

--- a/__tests__/__snapshots__/no-config.test.js.snap
+++ b/__tests__/__snapshots__/no-config.test.js.snap
@@ -7,7 +7,7 @@ Object {
       "extension": ".html",
       "name": "index.html",
       "path": "<TEMP_DIR>/_underreact-site/index.html",
-      "size": 7004,
+      "size": 6983,
       "type": "file",
     },
     Object {
@@ -71,7 +71,7 @@ Object {
   ],
   "name": "_underreact-site",
   "path": "<TEMP_DIR>/_underreact-site",
-  "size": 179083,
+  "size": 179062,
   "type": "directory",
 }
 `;

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -3,8 +3,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
-const htmlSource = ({ renderCssLinks, renderJsBundles }) => {
-  return `
+const htmlSource = `
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -13,15 +12,13 @@ const htmlSource = ({ renderCssLinks, renderJsBundles }) => {
       <title>Fancy examples</title>
       <link href="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.min.css" rel="stylesheet">
       <script async defer src="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.js"></script>
-      ${renderCssLinks()}
     </head>
     <body>
       <div id="app"></div>
-      ${renderJsBundles()}
     </body>
     </html>
   `;
-};
+
 
 module.exports = ({ webpack }) => {
   return {

--- a/lib/config/__snapshots__/urc.test.js.snap
+++ b/lib/config/__snapshots__/urc.test.js.snap
@@ -9,7 +9,19 @@ Urc {
   "compileNodeModules": false,
   "devServerHistoryFallback": false,
   "hot": false,
-  "htmlSource": [Function],
+  "htmlSource": "
+    <!DOCTYPE html>
+    <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+      <title>Underreact app</title>
+    </head>
+    <body>
+      <div id=\\"app\\"></div>
+    </body>
+    </html>
+  ",
   "isDevelopmentMode": true,
   "isProductionMode": false,
   "jsEntry": "/fake-volume/src/entry.js",
@@ -41,7 +53,19 @@ Urc {
   "compileNodeModules": false,
   "devServerHistoryFallback": false,
   "hot": false,
-  "htmlSource": [Function],
+  "htmlSource": "
+    <!DOCTYPE html>
+    <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+      <title>Underreact app</title>
+    </head>
+    <body>
+      <div id=\\"app\\"></div>
+    </body>
+    </html>
+  ",
   "isDevelopmentMode": false,
   "isProductionMode": true,
   "jsEntry": "/fake-volume/src/entry.js",
@@ -73,7 +97,19 @@ Urc {
   "compileNodeModules": false,
   "devServerHistoryFallback": false,
   "hot": true,
-  "htmlSource": [Function],
+  "htmlSource": "
+    <!DOCTYPE html>
+    <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+      <title>Underreact app</title>
+    </head>
+    <body>
+      <div id=\\"app\\"></div>
+    </body>
+    </html>
+  ",
   "isDevelopmentMode": true,
   "isProductionMode": false,
   "jsEntry": "/fake-volume/src/entry.js",
@@ -105,7 +141,19 @@ Urc {
   "compileNodeModules": false,
   "devServerHistoryFallback": false,
   "hot": false,
-  "htmlSource": [Function],
+  "htmlSource": "
+    <!DOCTYPE html>
+    <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+      <title>Underreact app</title>
+    </head>
+    <body>
+      <div id=\\"app\\"></div>
+    </body>
+    </html>
+  ",
   "isDevelopmentMode": false,
   "isProductionMode": true,
   "jsEntry": "/fake-volume/src/entry.js",
@@ -137,7 +185,19 @@ Urc {
   "compileNodeModules": false,
   "devServerHistoryFallback": false,
   "hot": false,
-  "htmlSource": [Function],
+  "htmlSource": "
+    <!DOCTYPE html>
+    <html lang=\\"en\\">
+    <head>
+      <meta charset=\\"UTF-8\\">
+      <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+      <title>Underreact app</title>
+    </head>
+    <body>
+      <div id=\\"app\\"></div>
+    </body>
+    </html>
+  ",
   "isDevelopmentMode": true,
   "isProductionMode": false,
   "jsEntry": "/fake-volume/src/entry.js",

--- a/lib/config/validate-config.js
+++ b/lib/config/validate-config.js
@@ -14,7 +14,7 @@ function validateConfig(rawConfig = {}) {
         compileNodeModules: v.oneOfType(v.boolean, v.arrayOf(v.string)),
         devServerHistoryFallback: v.boolean,
         hot: v.boolean,
-        htmlSource: v.func,
+        htmlSource: v.oneOfType(validatePromise, v.string),
         jsEntry: validateAbsolutePaths,
         liveReload: v.boolean,
         modernBrowserTest: v.string,
@@ -42,5 +42,11 @@ function validateConfig(rawConfig = {}) {
 function validateAbsolutePaths(value) {
   if (typeof value !== 'string' || !path.isAbsolute(value)) {
     return 'absolute path';
+  }
+}
+
+function validatePromise(value) {
+  if (Promise.resolve(value) !== value) {
+    return 'promise';
   }
 }

--- a/lib/default-html.js
+++ b/lib/default-html.js
@@ -1,20 +1,15 @@
 'use strict';
 
-module.exports = ({ renderCssLinks, renderJsBundles, polyfillScript }) => {
-  return `
+module.exports = `
     <!DOCTYPE html>
     <html lang="en">
     <head>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Underreact app</title>
-      ${polyfillScript()}
-      ${renderCssLinks()}
     </head>
     <body>
       <div id="app"></div>
-      ${renderJsBundles()}
     </body>
     </html>
   `;
-};

--- a/lib/webpack-config/create-webpack-config.test.js
+++ b/lib/webpack-config/create-webpack-config.test.js
@@ -24,9 +24,7 @@ test('Basic Test', () => {
   getUserConfig.mockResolvedValueOnce({
     siteBasePath: 'fancy',
     publicAssetsPath: 'cacheable-things',
-    htmlSource: () => {
-      return `<html></html>`;
-    },
+    htmlSource: `<html></html>`,
     webpackLoaders: [
       {
         test: /\.less$/,

--- a/lib/webpack-config/generate-html-template.js
+++ b/lib/webpack-config/generate-html-template.js
@@ -9,11 +9,7 @@ module.exports = function generateHtmlTemplate({
 }) {
   return Promise.resolve(
     // TOFIX: We need to make sure the urc.htmlSource returns a valid html
-    urc.htmlSource({
-      polyfillScript: () => '', // TOFIX: Remove these redundant callbacks
-      renderJsBundles: () => '',
-      renderCssLinks: () => ''
-    })
+    urc.htmlSource
   ).then(html =>
     html
       .replace(


### PR DESCRIPTION
With our new Webpack pipeline, we don't need to keep `htmlSource` as a function.