### PR TITLE
Fix root relative urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ By default, for example, the main JS chunk will be written to `underreact-assets
 Type `string`. Absolute path, please. Default: `${project-root}/public/`.
 
 Any files you put into this directory will be copied, without processing, into the [`outputDirectory`](#outputdirectory).
-You can put images, favicons, data files, and anything else you want in here.
+You can put images, favicons, data files, and anything else you want in here. To reference these assets in your Javascript code, you use the `BASE_PATH` environment variable, Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
 
 In the default value, `project-root` refers to the directory of your `underreact.config.js` file.
 
@@ -531,7 +531,7 @@ In the default value, `project-root` refers to the directory of your `underreact
 
 Type: `string`. Default: `'/'`.
 
-Path to the base directory on the domain where the site will be deployed. The default value is the domain's root.
+Path to the base directory on the domain where the site will be deployed. The default value is the domain's root. To help create valid links, Underreact exposes this value to your source with an environment variable `BASE_PATH`. Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
 
 **Tip**: There's a good chance your app isn't at the root of your domain. So this option represents the path of your site *within* that domain. For example, if your app is at `https://www.special.com/ketchup/*`, you should set `siteBasePath: '/ketchup'`.
 
@@ -638,6 +638,21 @@ function Header() {
   return <img src={logo} alt="Logo" />;
 }
 ```
+
+It is generally a good idea to use the above method for importing assets, because:
+
+- throws a compilation error when an asset is missing.
+- filenames include hashing for browser caching.
+
+If you cannot use this method and want to place some of your assets in the [publicDirectory](#publicdirectory), you can create links with the help of the in built environment variable `BASE_PATH`:
+
+```js
+function Header() {
+  return <img src={process.env.BASE_PATH + '/logo.png'} alt="Logo" />;
+}
+```
+
+The environment variable `BASE_PATH` is automatically set for you and is equivalent to the value of [`siteBasePath`](#sitebasepath).
 
 ### How do I enable hot module reloading ?
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ By default, for example, the main JS chunk will be written to `underreact-assets
 Type `string`. Absolute path, please. Default: `${project-root}/public/`.
 
 Any files you put into this directory will be copied, without processing, into the [`outputDirectory`](#outputdirectory).
-You can put images, favicons, data files, and anything else you want in here. To reference these assets in your Javascript code, you use the `BASE_PATH` environment variable, Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
+You can put images, favicons, data files, and anything else you want in here. To reference these assets in your Javascript code, you can use the `BASE_PATH` environment variable. Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
 
 In the default value, `project-root` refers to the directory of your `underreact.config.js` file.
 
@@ -639,12 +639,12 @@ function Header() {
 }
 ```
 
-It is generally a good idea to use the above method for importing assets, because:
+It is generally a good idea to use the above method for importing assets because:
 
-- throws a compilation error when an asset is missing.
-- filenames include hashing for browser caching.
+- It would throw a compilation error when an asset is missing.
+- The assets would be processed by Underreact and would get hash added to their filenames for a better caching.
 
-If you cannot use this method and want to place some of your assets in the [publicDirectory](#publicdirectory), you can create links with the help of the in built environment variable `BASE_PATH`:
+If you cannot use this method, you can place assets in the [`publicDirectory`](#publicdirectory) and create a link using the `BASE_PATH` environment variable as shown below:
 
 ```js
 function Header() {
@@ -652,7 +652,7 @@ function Header() {
 }
 ```
 
-The environment variable `BASE_PATH` is automatically set for you and is equivalent to the value of [`siteBasePath`](#sitebasepath).
+The `BASE_PATH` environment variable is automatically set by Underreact and is equivalent to the value of [`siteBasePath`](#sitebasepath). The `BASE_PATH`'s value would never end with a `/`, even if your `siteBasePath` does.
 
 ### How do I enable hot module reloading ?
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ By default, for example, the main JS chunk will be written to `underreact-assets
 Type `string`. Absolute path, please. Default: `${project-root}/public/`.
 
 Any files you put into this directory will be copied, without processing, into the [`outputDirectory`](#outputdirectory).
-You can put images, favicons, data files, and anything else you want in here. To reference these assets in your Javascript code, you can use the `BASE_PATH` environment variable. Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
+You can put images, favicons, data files, and anything else you want in here. To reference these assets in your Javascript code, you can use the `BASE_PATH` environment variable. Read ["How do I include SVGs, images, and videos?"](#how-do-i-include-svgs-images-and-videos).
 
 In the default value, `project-root` refers to the directory of your `underreact.config.js` file.
 
@@ -531,7 +531,7 @@ In the default value, `project-root` refers to the directory of your `underreact
 
 Type: `string`. Default: `'/'`.
 
-Path to the base directory on the domain where the site will be deployed. The default value is the domain's root. To help create valid links, Underreact exposes this value to your source with an environment variable `BASE_PATH`. Read [How do I include SVGs, images, and videos?](#how-do-i-include-svgs-images-and-videos).
+Path to the base directory on the domain where the site will be deployed. The default value is the domain's root. To help create valid links, Underreact exposes this value to your source with an environment variable `BASE_PATH`. Read ["How do I include SVGs, images, and videos?"](#how-do-i-include-svgs-images-and-videos).
 
 **Tip**: There's a good chance your app isn't at the root of your domain. So this option represents the path of your site *within* that domain. For example, if your app is at `https://www.special.com/ketchup/*`, you should set `siteBasePath: '/ketchup'`.
 
@@ -641,8 +641,8 @@ function Header() {
 
 It is generally a good idea to use the above method for importing assets because:
 
-- It would throw a compilation error when an asset is missing.
-- The assets would be processed by Underreact and would get hash added to their filenames for a better caching.
+- It will throw a compilation error when an asset is missing.
+- It adds a hash to the filenames for client level cache invalidation.
 
 If you cannot use this method, you can place assets in the [`publicDirectory`](#publicdirectory) and create a link using the `BASE_PATH` environment variable as shown below:
 
@@ -652,7 +652,7 @@ function Header() {
 }
 ```
 
-The `BASE_PATH` environment variable is automatically set by Underreact and is equivalent to the value of [`siteBasePath`](#sitebasepath). The `BASE_PATH`'s value would never end with a `/`, even if your `siteBasePath` does.
+The `BASE_PATH` environment variable is automatically set by Underreact and is equivalent to the value of [`siteBasePath`](#sitebasepath). `BASE_PATH`'s value will never end with a `/`, even if your `siteBasePath` does.
 
 ### How do I enable hot module reloading ?
 

--- a/commands/serve-static.js
+++ b/commands/serve-static.js
@@ -59,10 +59,10 @@ function startServer(urc) {
   const server = http.createServer((request, response) => {
     return handler(request, response, serverOpts, {
       stat(requestedPath) {
-        // Prevent accessing incorrect absolute paths. For example,
+        // Prevent accessing incorrect root relative paths. For example,
         // if the `base_path=fancy` and there is an image with
         // path `<root>/public/img/xyz.jpg` in the publicDirectory,
-        // we would want to prevent ths user from loading `<img src='/img/xyz.jpg'>`
+        // we will want to prevent ths user from loading `<img src='/img/xyz.jpg'>`
         // and instead allow loading of <img src='/fancy/img/xyz.jpg'>.
         if (
           !requestedPath.startsWith(

--- a/commands/serve-static.js
+++ b/commands/serve-static.js
@@ -77,6 +77,18 @@ function startServer(urc) {
 
 function stripSiteBasePath({ requestedPath, urc }) {
   const normalizedSiteBasePath = urc.siteBasePath.replace(/\//g, path.sep);
+  // Prevent accessing incorrect absolute paths. For example,
+  // if the `base_path=fancy` and there is an image with
+  // path `<root>/public/img/xyz.jpg` in the publicDirectory,
+  // we would want to prevent ths user from loading `<img src='/img/xyz.jpg'>`
+  // and instead allow loading of <img src='/fancy/img/xyz.jpg'>.
+  if (
+    !requestedPath.startsWith(
+      path.join(urc.outputDirectory, normalizedSiteBasePath)
+    )
+  ) {
+    return '';
+  }
   const pathToReplace = path.join(
     urc.outputDirectory,
     normalizedSiteBasePath,

--- a/commands/start.js
+++ b/commands/start.js
@@ -39,13 +39,17 @@ function watchWebpack(urc) {
     return Promise.reject(error);
   }
 
-  const normalizedBasePath = urlJoin('/', urc.siteBasePath, '/');
+  const normalizedBasePath = urlJoin(urc.siteBasePath, '/');
+
   return new Promise(resolve => {
     const server = new WebpackDevServer(compiler, {
       publicPath: urc.siteBasePath,
       before(app) {
         app.use((req, res, next) => {
-          if (req.url === '/' || req.url === urlJoin('/', urc.siteBasePath)) {
+          if (
+            req.url !== normalizedBasePath &&
+            (req.url === '/' || req.url === urlJoin('/', urc.siteBasePath))
+          ) {
             res.redirect(normalizedBasePath);
           } else {
             next();
@@ -65,7 +69,6 @@ function watchWebpack(urc) {
           })
         );
       },
-      // contentBase: urc.publicDirectory,
       // We have our own custom logging interface,
       // hence, we can quieten down `WebpackDevServer`.
       clientLogLevel: 'none',

--- a/commands/start.js
+++ b/commands/start.js
@@ -59,8 +59,8 @@ function watchWebpack(urc) {
         // We are using this middleware instead of the `contentBase` property
         // as webpack-dev-server doesn't allow for accessing public directory
         // contents prefixed with site base path. For example, if we have
-        // `basePath=foo` and an image in public directory with file path `<root>/public/img/xyz.jpg`,
-        // the correct url for this image would be `localhost:[port]/foo/img/xyz.jpg`
+        // `basePath=foo` and an image in the public directory with file path `<root>/public/img/xyz.jpg`,
+        // the correct url for this image is `localhost:[port]/foo/img/xyz.jpg`
         // and not `localhost:[port]/img/xyz.jpg`.
         app.use(
           normalizedBasePath,

--- a/examples/fancy/src/app.js
+++ b/examples/fancy/src/app.js
@@ -45,7 +45,7 @@ class App extends React.Component {
         <p>Background image snowflake:</p>
         <div className="snowflake" style={{ height: 300, width: 300 }} />
         <p>Real image snowflake:</p>
-        <img src="images/snowflake.jpg" />
+        <img src={`${process.env.BASE_PATH}/images/snowflake.jpg`} />
         <p>
           The library <code>p-finally</code> is not ES5, so this page should
           throw an error in older browsers like IE11.

--- a/lib/config/__snapshots__/urc.test.js.snap
+++ b/lib/config/__snapshots__/urc.test.js.snap
@@ -259,6 +259,7 @@ exports[`not setting polyfill fallbacks to default path 1`] = `"<PROJECT_ROOT>/p
 
 exports[`reads environment variables 1`] = `
 Object {
+  "BASE_PATH": "",
   "DEPLOY_ENV": "development",
   "MY_ENV_1": 1,
   "MY_ENV_2": 2,

--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -51,6 +51,11 @@ module.exports = class Urc {
       urc.liveReload = false;
     }
   }
+  getBasePathEnv() {
+    // remove the trailing slash to allow for the possibility
+    // of BASE_PATH + '/a/b/c.jpg'.
+    return this.siteBasePath.replace(/\/$/, '');
+  }
 
   readClientEnvVars() {
     if (this.environmentVariables.hasOwnProperty('DEPLOY_ENV')) {
@@ -69,7 +74,8 @@ module.exports = class Urc {
       // Most importantly, it switches React into the correct mode.
       NODE_ENV: process.env.NODE_ENV || this.mode,
       // Useful for providing a way to namespace different deployment targets
-      DEPLOY_ENV: process.env.DEPLOY_ENV || 'development'
+      DEPLOY_ENV: process.env.DEPLOY_ENV || 'development',
+      BASE_PATH: this.getBasePathEnv()
     });
   }
 

--- a/lib/config/urc.js
+++ b/lib/config/urc.js
@@ -51,6 +51,7 @@ module.exports = class Urc {
       urc.liveReload = false;
     }
   }
+
   getBasePathEnv() {
     // remove the trailing slash to allow for the possibility
     // of BASE_PATH + '/a/b/c.jpg'.

--- a/lib/webpack-config/__snapshots__/create-webpack-config.test.js.snap
+++ b/lib/webpack-config/__snapshots__/create-webpack-config.test.js.snap
@@ -193,12 +193,14 @@ Object {
     },
     EnvironmentPlugin {
       "defaultValues": Object {
+        "BASE_PATH": "/fancy",
         "DEPLOY_ENV": "development",
         "NODE_ENV": "test",
       },
       "keys": Array [
         "NODE_ENV",
         "DEPLOY_ENV",
+        "BASE_PATH",
       ],
     },
     MiniCssExtractPlugin {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "remark-preset-davidtheclark": "^0.8.1",
     "resolve-pkg": "^1.0.0",
     "serve-handler": "^5.0.5",
+    "serve-static": "^1.13.2",
     "source-map-url": "^0.4.0",
     "style-loader": "^0.23.0",
     "terser-webpack-plugin": "^1.1.0",


### PR DESCRIPTION
This modifies the way webpack-dev-server serves the public assets folder. 
Due to shortcomings, as mentioned in https://github.com/webpack/webpack-dev-server/issues/954, I am using an express middleware to serve static files.

@davidtheclark for review, please.

(closes https://github.com/mapbox/underreact/issues/77)