### PR TITLE
Expose base path to html 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Allow for base path injection in `htmlSource`.
+
 ## 0.4.0
 
 - **Bug:**: Fixes the way Underreact handles root relative urls.

--- a/examples/fancy/public/blink.css
+++ b/examples/fancy/public/blink.css
@@ -1,0 +1,11 @@
+.blink{
+    animation:blinkText 1.5s infinite;
+}
+
+@keyframes blinkText{
+    0%  {    color: rgba(0,0,0,0);    }
+    49% {    color: rgba(0,0,0,0.33); }
+    50% {    color: rgba(0,0,0,0.33); }
+    99% {    color: rgba(0,0,0,0.33); }
+    100%{    color: rgba(0,0,0,0);    }
+}

--- a/examples/fancy/src/app.js
+++ b/examples/fancy/src/app.js
@@ -34,6 +34,9 @@ class App extends React.Component {
           {typeof DEFINE_WORKED === 'undefined' ? 'No' : DEFINE_WORKED}
         </p>
         <p>Less-loading worked if this text is light blue.</p>
+        <p className="blink">
+         HTML base path injection works if this text blinks.
+        </p>
         <p>
           Value of the env variable CLIENT_TOKEN:{' '}
           {process.env.CLIENT_TOKEN}

--- a/examples/fancy/underreact.config.js
+++ b/examples/fancy/underreact.config.js
@@ -3,7 +3,7 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const path = require('path');
 
-const htmlSource = `
+const htmlSource = ({basePath}) => `
     <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -11,6 +11,7 @@ const htmlSource = `
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Fancy examples</title>
       <link href="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.min.css" rel="stylesheet">
+      <link href="${basePath}/blink.css" rel="stylesheet">
       <script async defer src="https://api.mapbox.com/mapbox-assembly/v0.21.2/assembly.js"></script>
     </head>
     <body>

--- a/lib/config/validate-config.js
+++ b/lib/config/validate-config.js
@@ -13,7 +13,7 @@ function validateConfig(rawConfig = {}) {
         compileNodeModules: v.oneOfType(v.boolean, v.arrayOf(v.string)),
         devServerHistoryFallback: v.boolean,
         hot: v.boolean,
-        htmlSource: v.oneOfType(validatePromise, v.string),
+        htmlSource: v.oneOfType(validatePromise, v.string, v.func),
         jsEntry: validateAbsolutePaths,
         liveReload: v.boolean,
         environmentVariables: v.plainObject,

--- a/lib/webpack-config/generate-html-template.js
+++ b/lib/webpack-config/generate-html-template.js
@@ -7,7 +7,13 @@ module.exports = function generateHtmlTemplate({
   webpackCompilation,
   publicPath
 }) {
-  return Promise.resolve(urc.htmlSource).then(html =>
+  let htmlSource = urc.htmlSource;
+
+  if (typeof urc.htmlSource === 'function') {
+    htmlSource = urc.htmlSource({ basePath: urc.getBasePathEnv() });
+  }
+
+  return Promise.resolve(htmlSource).then(html =>
     html
       .replace(
         '<head>',


### PR DESCRIPTION
I noticed that there is no simple way to expose the normalised site base path to the html  content of an Underreact project. This PR aims to fix that.

@davidtheclark for review, please.