### PR TITLE
use project-wide babel.config.js to compile node_modules

### DIFF
--- a/lib/webpack-config/babel-loader-config.js
+++ b/lib/webpack-config/babel-loader-config.js
@@ -74,6 +74,9 @@ function getConfigForNodeModules(urc) {
     }
     return options;
   };
+  
+  const babelConfigPath = path.join(urc.rootDirectory, 'babel.config.js');
+  const exists = fs.existsSync(babelConfigPath);
 
   const loaderConfig = {
     test: /\.js$/,
@@ -98,7 +101,7 @@ function getConfigForNodeModules(urc) {
       // Babel to assume CommonJS unless an `import` or `export` is present in the file.
       sourceType: 'unambiguous',
       babelrc: false,
-      configFile: false,
+      configFile: exists ? babelConfigPath : false,
       compact: false,
       cacheDirectory: true,
       cacheCompression: false,


### PR DESCRIPTION
this fix #89 