### PR TITLE
Enable setting the host to other than 127.0.0.1

### DIFF
--- a/bin/underreact.js
+++ b/bin/underreact.js
@@ -48,6 +48,15 @@ const configOption = [
   }
 ];
 
+const hostOption = [
+  'host',
+  {
+    description: 'Host',
+    type: 'string',
+    default: '127.0.0.1'
+  }
+];
+
 const portOption = [
   'port',
   {
@@ -104,6 +113,7 @@ yargs
 function defineStart(y) {
   y.version(false)
     .option(...configOption)
+    .option(...hostOption)
     .option(...portOption)
     .option(...modeOption('development'))
     .option(...statsOption)

--- a/commands/start.js
+++ b/commands/start.js
@@ -76,12 +76,13 @@ function watchWebpack(urc) {
       historyApiFallback: urc.devServerHistoryFallback && {
         index: urc.siteBasePath
       },
+      host: urc.host,
       port: urc.port,
       compress: urc.isProductionMode,
       hot: urc.hot
     });
 
-    server.listen(urc.port, '127.0.0.1', () => {
+    server.listen(urc.port, urc.host, () => {
       resolve();
       return;
     });

--- a/lib/config/__snapshots__/urc.test.js.snap
+++ b/lib/config/__snapshots__/urc.test.js.snap
@@ -13,6 +13,7 @@ Urc {
   "compileNodeModules": true,
   "devServerHistoryFallback": false,
   "environmentVariables": Object {},
+  "host": "127.0.0.1",
   "hot": false,
   "htmlSource": "
     <!DOCTYPE html>
@@ -62,6 +63,7 @@ Urc {
   "compileNodeModules": true,
   "devServerHistoryFallback": false,
   "environmentVariables": Object {},
+  "host": "127.0.0.1",
   "hot": false,
   "htmlSource": "
     <!DOCTYPE html>
@@ -111,6 +113,7 @@ Urc {
   "compileNodeModules": true,
   "devServerHistoryFallback": false,
   "environmentVariables": Object {},
+  "host": "127.0.0.1",
   "hot": true,
   "htmlSource": "
     <!DOCTYPE html>
@@ -160,6 +163,7 @@ Urc {
   "compileNodeModules": true,
   "devServerHistoryFallback": false,
   "environmentVariables": Object {},
+  "host": "127.0.0.1",
   "hot": false,
   "htmlSource": "
     <!DOCTYPE html>
@@ -209,6 +213,7 @@ Urc {
   "compileNodeModules": true,
   "devServerHistoryFallback": false,
   "environmentVariables": Object {},
+  "host": "127.0.0.1",
   "hot": false,
   "htmlSource": "
     <!DOCTYPE html>

--- a/lib/config/validate-config.js
+++ b/lib/config/validate-config.js
@@ -12,6 +12,7 @@ function validateConfig(rawConfig = {}) {
         browserslist: v.oneOfType(v.plainObject, v.arrayOf(v.string)),
         compileNodeModules: v.oneOfType(v.boolean, v.arrayOf(v.string)),
         devServerHistoryFallback: v.boolean,
+        host: v.string,
         hot: v.boolean,
         htmlSource: v.oneOfType(validatePromise, v.string, v.func),
         jsEntry: validateAbsolutePaths,

--- a/lib/default-underreact.config.js
+++ b/lib/default-underreact.config.js
@@ -30,6 +30,7 @@ module.exports = (cliOpts = {}) => {
     modernBrowserTest: `'fetch' in window && 'assign' in Object`,
     outputDirectory: path.join(rootDirectory, '_site'),
     polyfill: path.resolve(underreactRoot, 'polyfill', 'index.js'),
+    host: cliOpts.host || '127.0.0.1',
     port: cliOpts.port || 8080,
     postcssPlugins: [],
     publicAssetsPath: 'underreact-assets',

--- a/lib/utils/get-cli-opts.js
+++ b/lib/utils/get-cli-opts.js
@@ -9,6 +9,7 @@ function getCliOpts(command, argv) {
     configPath: path.resolve(argv.config),
     mode: argv.mode,
     stats: argv.stats,
+    host: argv.host,
     port: argv.port
   };
   return cliOpts;


### PR DESCRIPTION
This unblocks being able to run `underreact start --host 0.0.0.0` inside a docker container, such as you may want to do if you have multiple applications (services, frontends, etc.) you want to run locally.

Per the [DevServer docs](https://webpack.js.org/configuration/dev-server/#devserverhost), we need to be able to listen on `0.0.0.0` to be reachable outside the docker container (in other containers, from your browser on the host machine etc.).