### PR TITLE
feat(package.json): add resolution section to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
     "react-dom": "^16.4.1",
     "tempy": "^0.2.1"
   },
+  "resolutions": {
+    "minimist": "^1.2.5",
+    "acorn": "^6.4.1"
+  },
   "bin": {
     "underreact": "bin/underreact.js"
   },


### PR DESCRIPTION
add resolution section to package.json, it helps to resolve different versions of dependencies in package-lock.json. especially helpful for vulnerable dependencies as minimist

as consumer of underreact, I faced situation when it's dependency (minimist, it's dependency of dependency...) triggered security vulnerability in our repository. we fixed it with resolution, so I'm suggesting the same fix for underreact