### PR TITLE
Add deprecation notice to Underreact.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED!
+
+As of April 2022, we are deprecating Underreact and do not recommend usage on new projects. Development will only occur on an exemption basis for existing, internal Mapbox use-cases.
+
+New projects should use an alternative such as [Create React App](https://create-react-app.dev/) or [Vite](https://vitejs.dev/).
+
+---
+
 # @mapbox/underreact
 
 Minimal, extensible React app build system that you won't need to eject.


### PR DESCRIPTION
# Description

Closes https://github.com/mapbox/underreact/issues/112

After discussing with @tristen, Mapbox and the community should use other solutions for new projects. When technically feasible, existing projects should migrate away from Underreact to community solutions.

Bundlers that may work for your needs:
- [Create React App](https://create-react-app.dev/)
- [Vite](https://vitejs.dev/)

Internal Mapboxers can find support in the `#frontend` channel on Slack.